### PR TITLE
[Feat] 회원 정보 관련 API 구현

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/apiPayload/ApiResponse.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/ApiResponse.java
@@ -30,9 +30,8 @@ public class ApiResponse<T> {
             return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
     }
 
-
     // 실패한 경우 응답 생성
     public static <T> ApiResponse<T> onFailure(String code, String message, T data){
-        return new ApiResponse<>(true, code, message, data);
+        return new ApiResponse<>(false, code, message, data);
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -17,8 +17,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // 멤버 관련 응답
-    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
-    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임은 필수 입니다."),
 
     // Article Error
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),

--- a/src/main/java/TtattaBackend/ttatta/apiPayload/exception/handler/ExceptionHandler.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/exception/handler/ExceptionHandler.java
@@ -1,0 +1,10 @@
+package TtattaBackend.ttatta.apiPayload.exception.handler;
+
+import TtattaBackend.ttatta.apiPayload.code.BaseErrorCode;
+import TtattaBackend.ttatta.apiPayload.exception.GeneralException;
+
+public class ExceptionHandler extends GeneralException {
+    public ExceptionHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -32,6 +32,14 @@ public class UserConverter {
                 .build();
     }
 
+    // 미구현
+    public static UserResponseDTO.RefreshResultDTO toRefreshResultDTO(Users users) {
+        return UserResponseDTO.RefreshResultDTO.builder()
+                .userId(users.getId())
+                .refreshToken(users.getRefreshToken())
+                .build();
+    }
+
     public static UserResponseDTO.UserInfoResultDTO toUserInfoResultDTO(Users users) {
         return UserResponseDTO.UserInfoResultDTO.builder()
                 .userId(users.getId())

--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -31,4 +31,16 @@ public class UserConverter {
                 .createdAt(users.getCreatedAt())
                 .build();
     }
+
+    public static UserResponseDTO.UserInfoResultDTO toUserInfoResultDTO(Users users) {
+        return UserResponseDTO.UserInfoResultDTO.builder()
+                .userId(users.getId())
+                .nickname(users.getNickname())
+                .loginType(users.getLoginType())
+                .email(users.getEmail())
+                .profileImg(users.getProfileImage())
+                .point(users.getPoint())
+                .status(users.getStatus())
+                .build();
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/domain/Users.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Users.java
@@ -80,4 +80,21 @@ public class Users extends BaseEntity {
     public void encodePassword(String password) {
         this.password = password;
     }
+
+    // setter 대신 명시적인 표현을 위해 update 표현 사용
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
+    public void updatePoint(Long point) {
+        this.point = point;
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -8,4 +8,5 @@ public interface UserCommandService {
     Users signUp(UserRequestDTO.SignUpRequestDTO request);
     Users signIn(UserRequestDTO.SignInRequestDTO request);
     Users getUserInfo(Long userId);
+    Users updateUserInfo(Long userId, UserRequestDTO.UpdateRequestDTO request);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -7,4 +7,5 @@ public interface UserCommandService {
     Users createTestUser();
     Users signUp(UserRequestDTO.SignUpRequestDTO request);
     Users signIn(UserRequestDTO.SignInRequestDTO request);
+    Users getUserInfo(Long userId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -9,4 +9,5 @@ public interface UserCommandService {
     Users signIn(UserRequestDTO.SignInRequestDTO request);
     Users getUserInfo(Long userId);
     Users updateUserInfo(Long userId, UserRequestDTO.UpdateRequestDTO request);
+    void deleteUser(Long userId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -7,6 +7,9 @@ public interface UserCommandService {
     Users createTestUser();
     Users signUp(UserRequestDTO.SignUpRequestDTO request);
     Users signIn(UserRequestDTO.SignInRequestDTO request);
+    Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request);    // 미구현
+    Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
+    Users refresh(String request);  // 미구현
     Users getUserInfo(Long userId);
     Users updateUserInfo(Long userId, UserRequestDTO.UpdateRequestDTO request);
     void deleteUser(Long userId);

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -75,4 +75,19 @@ public class UserCommandServiceImpl implements UserCommandService {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
     }
+
+    @Override
+    public Users updateUserInfo(Long userId, UserRequestDTO.UpdateRequestDTO request) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        // 입력 들어온 값만 업데이트
+        request.getNickname().ifPresent(user::updateNickname);
+        request.getEmail().ifPresent(user::updateEmail);
+        request.getPhoneNumber().ifPresent(user::updatePhoneNumber);
+        request.getProfileImage().ifPresent(user::updateProfileImage);
+        request.getPoint().ifPresent(user::updatePoint);
+
+        return userRepository.save(user);
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package TtattaBackend.ttatta.service.UserService;
 
+import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
 import TtattaBackend.ttatta.converter.UserConverter;
 import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.domain.enums.Gender;
@@ -14,11 +15,12 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+
+import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -66,5 +68,11 @@ public class UserCommandServiceImpl implements UserCommandService {
         Users user = userRepository.findByUsername(authentication.getName()).orElse(null);
 
         return user;
+    }
+
+    @Override
+    public Users getUserInfo(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -90,4 +90,14 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         return userRepository.save(user);
     }
+
+    @Override
+    public void deleteUser(Long userId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        // 이후 유저에 연관된 모든 데이터 삭제해야함 cascade 설정 필요
+
+        userRepository.delete(user);
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -70,6 +70,27 @@ public class UserCommandServiceImpl implements UserCommandService {
         return user;
     }
 
+    // 미구현
+    @Override
+    public Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request) {
+        // 서비스 구현
+        return null;
+    }
+
+    // 미구현
+    @Override
+    public Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request) {
+        // 서비스 구현
+        return null;
+    }
+
+    // 미구현
+    @Override
+    public Users refresh(String request) {
+        // 서비스 구현
+        return null;
+    }
+
     @Override
     public Users getUserInfo(Long userId) {
         return userRepository.findById(userId)

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -59,6 +59,55 @@ public class UserController {
         );
     }
 
+
+    // 미구현
+    @Operation(summary = "카카오 회원가입", description =
+            "# 카카오 회원가입 API 입니다."
+    )
+    @PostMapping("/signup/kakao")
+    public ApiResponse<UserResponseDTO.UserSignUpResultDTO> signUpKakao(
+            @RequestBody UserRequestDTO.SignUpKakaoRequestDTO request
+    ) {
+        Users newUser = userCommandService.signUpKakao(request);
+        return ApiResponse.onSuccess(
+                UserConverter.toUserSignUpResultDTO(
+                        newUser
+                )
+        );
+    }
+
+    // 미구현
+    @Operation(summary = "카카오 로그인", description =
+            "# 카카오 로그인 API 입니다."
+    )
+    @PostMapping("/signin/kakao")
+    public ApiResponse<UserResponseDTO.UserSignInResultDTO> signInKakao(
+            @RequestBody UserRequestDTO.SignInKakaoRequestDTO request
+    ) {
+        Users user = userCommandService.signInKakao(request);
+        return ApiResponse.onSuccess(
+                UserConverter.toUserSignInResultDTO(
+                        user
+                )
+        );
+    }
+
+    // 미구현
+    @Operation(summary = "토큰 갱신", description =
+            "# 토큰 갱신 API 입니다. 리프레시 토큰을 header에 입력해주세요."
+    )
+    @PostMapping("/refresh")
+    public ApiResponse<UserResponseDTO.RefreshResultDTO> refreshToken(
+            @RequestHeader("refreshToken") String refreshToken
+    ) {
+        Users user = userCommandService.refresh(refreshToken);
+        return ApiResponse.onSuccess(
+                UserConverter.toRefreshResultDTO(
+                        user
+                )
+        );
+    }
+
     @Operation(summary = "회원 정보 조회", description =
             "# 회원 정보 조회 API 입니다. 회원의 ID를 입력해주세요."
     )

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -73,4 +73,20 @@ public class UserController {
                 )
         );
     }
+
+    @Operation(summary = "회원 정보 수정", description =
+            "# 회원 정보 수정 API 입니다. 회원의 ID와 수정할 정보를 입력해주세요.\n수정을 원하는 데이터만 보내도 수정 가능합니다."
+    )
+    @PatchMapping("/{userId}")
+    public ApiResponse<UserResponseDTO.UserInfoResultDTO> updateUserData(
+            @PathVariable Long userId,
+            @RequestBody UserRequestDTO.UpdateRequestDTO request
+    ) {
+        Users user = userCommandService.updateUserInfo(userId, request);
+        return ApiResponse.onSuccess(
+                UserConverter.toUserInfoResultDTO(
+                        user
+                )
+        );
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -78,7 +78,7 @@ public class UserController {
             "# 회원 정보 수정 API 입니다. 회원의 ID와 수정할 정보를 입력해주세요.\n수정을 원하는 데이터만 보내도 수정 가능합니다."
     )
     @PatchMapping("/{userId}")
-    public ApiResponse<UserResponseDTO.UserInfoResultDTO> updateUserData(
+    public ApiResponse<UserResponseDTO.UserInfoResultDTO> updateUserInfo(
             @PathVariable Long userId,
             @RequestBody UserRequestDTO.UpdateRequestDTO request
     ) {
@@ -88,5 +88,16 @@ public class UserController {
                         user
                 )
         );
+    }
+
+    @Operation(summary = "회원 탈퇴", description =
+            "# 회원 탈퇴 API 입니다. 회원의 ID를 입력해주세요."
+    )
+    @DeleteMapping("/{userId}")
+    public ApiResponse<Object> deleteUser(
+            @PathVariable Long userId
+    ) {
+        userCommandService.deleteUser(userId);
+        return ApiResponse.onSuccess("");
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -1,19 +1,14 @@
 package TtattaBackend.ttatta.web.controller;
 
 import TtattaBackend.ttatta.apiPayload.ApiResponse;
-import TtattaBackend.ttatta.apiPayload.code.status.SuccessStatus;
 import TtattaBackend.ttatta.converter.UserConverter;
 import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.service.UserService.UserCommandService;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -59,6 +54,21 @@ public class UserController {
         Users user = userCommandService.signIn(request);
         return ApiResponse.onSuccess(
                 UserConverter.toUserSignInResultDTO(
+                        user
+                )
+        );
+    }
+
+    @Operation(summary = "회원 정보 조회", description =
+            "# 회원 정보 조회 API 입니다. 회원의 ID를 입력해주세요."
+    )
+    @GetMapping("/{userId}")
+    public ApiResponse<UserResponseDTO.UserInfoResultDTO> getUserInfo(
+            @PathVariable Long userId
+    ) {
+        Users user = userCommandService.getUserInfo(userId);
+        return ApiResponse.onSuccess(
+                UserConverter.toUserInfoResultDTO(
                         user
                 )
         );

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Optional;
+
 public class UserRequestDTO {
     @Getter
     @Builder
@@ -23,5 +25,18 @@ public class UserRequestDTO {
     public static class SignInRequestDTO {
         private String username;
         private String password;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateRequestDTO {
+        // 입력 값을 선택적으로 받기 위해 Optional 사용
+        private Optional<String> nickname = Optional.empty();
+        private Optional<String> email = Optional.empty();
+        private Optional<String> phoneNumber = Optional.empty();
+        private Optional<String> profileImage = Optional.empty();
+        private Optional<Long> point = Optional.empty();
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -27,6 +27,25 @@ public class UserRequestDTO {
         private String password;
     }
 
+    // 미구현
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class SignUpKakaoRequestDTO {
+        private String kakaoToken;
+        private String nickname;
+    }
+
+    // 미구현
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class SignInKakaoRequestDTO {
+        private String kakaoToken;
+    }
+
     @Getter
     @Builder
     @AllArgsConstructor

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -33,6 +33,17 @@ public class UserResponseDTO {
         LocalDateTime createdAt;
     }
 
+    // 미구현
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RefreshResultDTO {
+        Long userId;
+        String accessToken;
+        String refreshToken;
+    }
+
     @Getter
     @Builder
     @NoArgsConstructor

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -1,6 +1,8 @@
 package TtattaBackend.ttatta.web.dto;
 
+import TtattaBackend.ttatta.domain.enums.Gender;
 import TtattaBackend.ttatta.domain.enums.LoginType;
+import TtattaBackend.ttatta.domain.enums.UserStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,5 +31,21 @@ public class UserResponseDTO {
         String nickname;
         LoginType loginType;
         LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserInfoResultDTO {
+        Long userId;
+        String nickname;
+        LoginType loginType;
+        String email;
+        String profileImg;
+        Long point;
+        UserStatus status;
+        Gender gender;
+        String phoneNum;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=ttatta


### PR DESCRIPTION
## #️⃣연관된 이슈
#12 

## 📝작업 내용
회원 정보 조회, 수정, 탈퇴 기능을 구현하였습니다.

## 🔎코드 설명
 **1. 유저 정보 조회**
path variable로 유저 ID를 입력
![image](https://github.com/user-attachments/assets/a80ac76f-4efe-41ad-ac3e-734b3ecbeb66)

**2. 유저 정보 수정**
역시 path variable로 유저 ID를 입력하고,
request body에 수정을 원하는 부분만 key:value 형태로 보내면 알아서 해당 부분만 수정 가능함
![image](https://github.com/user-attachments/assets/2d88df51-fc3d-4536-926e-83305d6bed7a)
![image](https://github.com/user-attachments/assets/c4c21107-092a-4772-abd1-80993e7d27af)


**3. 유저 탈퇴**
path variable에 유저 ID를 입력하면 해당 유저가 삭제됩니다.
단, 아직은 연관관계 연결이 없어서 괜찮지만 이후 타 테이블과 연결된다면 cascade 등을 이용한 연관 삭제가 추가되어야 함
![image](https://github.com/user-attachments/assets/491d5063-97b8-4935-8661-2c9ebe5a51db)

**4. Exception Handler 추가**
더욱 편한 에러 처리를 위해 추가하였습니다.
Service에서 `.orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));`
이런식으로 ErrorStatus에서 추가한 error code를 바로 사용할 수 있습니다.

**5. 나머지 API DTO 및 Controller 작성**
현재 카카오 로그인, 카카오 회원가입, 토큰 갱신 API의 DTO, Controller는 작성했고
아직 아이디, 비번 찾기, 로그아웃은 작성하지 못했습니다. @Jinho622 나머지 부탁드려요!


## 💬고민사항 및 리뷰 요구사항 (Optional)
회원 탈퇴의 경우 result를 null로 할지, 빈 문자열 ""로 할지 고민입니다.
null의 경우 result가 아예 표시되지 않음, 빈 문자열은 그래도 result = ""로 나옴

## 비고 (Optional)
x
