### PR TITLE
[Feat] validator annotation 예외처리 및 회원가입, 로그인 예외처리

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -16,15 +16,16 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-    // 멤버 관련 응답
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
+    // 회원 관련 응답 1000
+    USER_ID_NULL(HttpStatus.BAD_REQUEST, "USER_1001", "사용자 아이디는 필수 입니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_1002", "해당하는 사용자가 존재하지 않습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임은 필수 입니다."),
 
-    // Article Error
-    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
+    // 일기 관련 응답 2000
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_2001", "해당하는 일기가 존재하지 않습니다."),
 
-    // For test
-    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트");
+    // 일기 카테고리 관련 응답 3000
+    DIARY_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_CATEGORY_3001", "해당하는 일기 카테고리가 존재하지 않습니다.");
 
     // ~~~ 관련 응답 ....
 

--- a/src/main/java/TtattaBackend/ttatta/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/exception/ExceptionAdvice.java
@@ -8,6 +8,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -36,9 +37,9 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
     }
 
-//    @Override //빨간 줄 떠서 주석처리함
+    @Override
     public ResponseEntity<Object> handleMethodArgumentNotValid(
-            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatus status, WebRequest request) {
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
         Map<String, String> errors = new LinkedHashMap<>();
 

--- a/src/main/java/TtattaBackend/ttatta/domain/Users.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Users.java
@@ -31,7 +31,7 @@ public class Users extends BaseEntity {
     @Column(nullable = false, length = 8)
     private String nickname;
 
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false, length = 15)
     private String username;
 
     @Column(nullable = false, length = 100)

--- a/src/main/java/TtattaBackend/ttatta/validation/annotation/ExistUser.java
+++ b/src/main/java/TtattaBackend/ttatta/validation/annotation/ExistUser.java
@@ -1,0 +1,17 @@
+package TtattaBackend.ttatta.validation.annotation;
+
+import TtattaBackend.ttatta.validation.validator.ExistUserValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ExistUserValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistUser {
+    String message() default "해당하는 유저가 존재하지 않습니다."; // message대신 ErrorStatus에 정의한 message사용할 것임.
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/TtattaBackend/ttatta/validation/validator/ExistUserValidator.java
+++ b/src/main/java/TtattaBackend/ttatta/validation/validator/ExistUserValidator.java
@@ -1,0 +1,44 @@
+package TtattaBackend.ttatta.validation.validator;
+
+import TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus;
+import TtattaBackend.ttatta.repository.UserRepository;
+import TtattaBackend.ttatta.validation.annotation.ExistUser;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ExistUserValidator implements ConstraintValidator<ExistUser, Long> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void initialize(ExistUser constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long userId, ConstraintValidatorContext context) {
+        ErrorStatus errorStatus;
+
+        boolean isValid;
+
+        // null is invalid
+        if (userId == null) {
+            errorStatus = ErrorStatus.USER_ID_NULL;
+            isValid = false;
+        } else {
+            errorStatus = ErrorStatus.USER_NOT_FOUND;
+            isValid = userRepository.findById(userId).isPresent();
+        }
+
+        if (!isValid) { // ExistUser의 message대신 ErrorStatus의 message출력
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(errorStatus.getMessage()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -50,7 +50,7 @@ public class UserController {
     )
     @PostMapping("/signin")
     public ApiResponse<UserResponseDTO.UserSignInResultDTO> signIn(
-            @RequestBody UserRequestDTO.SignInRequestDTO request
+            @RequestBody @Valid UserRequestDTO.SignInRequestDTO request
     ) {
         Users user = userCommandService.signIn(request);
         return ApiResponse.onSuccess(

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -7,6 +7,7 @@ import TtattaBackend.ttatta.service.UserService.UserCommandService;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,7 +35,7 @@ public class UserController {
     )
     @PostMapping("/signup")
     public ApiResponse<UserResponseDTO.UserSignUpResultDTO> signUp(
-            @RequestBody UserRequestDTO.SignUpRequestDTO request
+            @RequestBody @Valid UserRequestDTO.SignUpRequestDTO request
     ) {
         Users newUser = userCommandService.signUp(request);
         return ApiResponse.onSuccess(

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryCategoryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryCategoryRequestDTO.java
@@ -1,6 +1,7 @@
 package TtattaBackend.ttatta.web.dto;
 
 import TtattaBackend.ttatta.domain.enums.CategoryColor;
+import TtattaBackend.ttatta.validation.annotation.ExistUser;
 import lombok.Getter;
 
 public class DiaryCategoryRequestDTO {
@@ -9,6 +10,7 @@ public class DiaryCategoryRequestDTO {
     public static class CreateCategoryDTO {
         String categoryName;
         CategoryColor categoryColor;
+        @ExistUser
         Long userId;
     }
 

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -1,5 +1,6 @@
 package TtattaBackend.ttatta.web.dto;
 
+import TtattaBackend.ttatta.validation.annotation.ExistUser;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -8,6 +9,7 @@ import java.util.Optional;
 public class DiaryRequestDTO {
     @Getter
     public static class PostDTO {
+        @ExistUser
         private Long userId;
 
         private Long diaryCategoryId;

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -1,5 +1,6 @@
 package TtattaBackend.ttatta.web.dto;
 
+import TtattaBackend.ttatta.validation.annotation.ExistUser;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -1,6 +1,8 @@
 package TtattaBackend.ttatta.web.dto;
 
 import TtattaBackend.ttatta.validation.annotation.ExistUser;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,8 +16,13 @@ public class UserRequestDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class SignUpRequestDTO {
+        @NotBlank(message = "이름은 빈값일 수 없습니다.")
+        @Size(max = 8, message = "닉네임은 1 ~ 8자이어야 합니다.")
         private String nickname;
+        @NotBlank(message = "아이디는 빈값일 수 없습니다.")
+        @Size(max = 15, message = "아이디는 1 ~ 15자이어야 합니다.")
         private String username;
+        @NotBlank(message = "비밀번호는 빈값일 수 없습니다.")
         private String password;
     }
 

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -31,7 +31,9 @@ public class UserRequestDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class SignInRequestDTO {
+        @NotBlank(message = "아이디는 빈값일 수 없습니다.")
         private String username;
+        @NotBlank(message = "비밀번호는 빈값일 수 없습니다.")
         private String password;
     }
   


### PR DESCRIPTION
## #️⃣연관된 이슈
> #25

## 📝작업 내용
> validator annotation 예외처리 및 회원가입, 로그인 예외처리

## 🔎코드 설명
> validator annotation 예외처리
> 1. dto에 적용할 annotation을 직접 만들어 사용, 현재 코드에서는 @ExistUser를 만들어 Request로 들어온 userId에 해당하는 유저가 없거나 userId가 null값으로 들어올 시 예외처리 해주었음.
> 2. 일기 작성 API에서 request body의 userId에 null값이 들어온 경우
> ![image](https://github.com/user-attachments/assets/d3d840ae-fe25-4f6d-9d0f-49eb74978e28)
> ![image](https://github.com/user-attachments/assets/58f40767-88f4-4982-9083-9d6a447d0f44)
> 3. 일기 작성 API에서 request body에 존재하지 않는 userId값이 들어온 경우
> ![image](https://github.com/user-attachments/assets/db274aef-1a6e-40a1-989a-f822b67ff376)
> ![image](https://github.com/user-attachments/assets/825bc470-b08b-4f44-ab06-c1c5cd8d8426)
> 4. 일기 카테고리 생성 API에도 위 2개의 예외처리 동일하게 적용

> 회원가입관련 예외처리
> 1. 닉네임, 아이디, 비밀번호가 빈값인 경우
> ![image](https://github.com/user-attachments/assets/e6aa4d1d-d340-45e2-a1a2-a862ae60f159)
> 2. 닉네임, 이이디가 규격에 맞지 않는 경우
> ![image](https://github.com/user-attachments/assets/7f7d0356-33ac-4313-8094-58c0fc341788)

> 로그인관련 예외처리
> 아이디, 비밀번호가 빈값인 경우
> ![image](https://github.com/user-attachments/assets/0f624b74-9d74-4233-abb6-9831300a428d)


## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> validator annotation 참고했던 링크 : https://hogwart-scholars.tistory.com/entry/Spring-Boot-ConstraintValidator%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%B4-%EB%82%98%EB%A7%8C%EC%9D%98-validator-%EB%A7%8C%EB%93%A4%EA%B8%B0
