### PR TITLE
[Refactor] diaries entity의 위도 경도 column의 type을 String에서 double로 변경

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
@@ -5,7 +5,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import software.amazon.ion.Decimal;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,11 +30,9 @@ public class Diaries extends BaseEntity {
 
     private LocalDateTime date;
 
-    @Column(nullable = false, length = 40)
-    private String latitude;
+    private Double latitude;
 
-    @Column(nullable = false, length = 40)
-    private String longitude;
+    private Double longitude;
 
     @Column(nullable = false, length = 50)
     private String locationName;

--- a/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
@@ -30,9 +30,9 @@ public class Diaries extends BaseEntity {
 
     private LocalDateTime date;
 
-    private Double latitude;
+    private double latitude;
 
-    private Double longitude;
+    private double longitude;
 
     @Column(nullable = false, length = 50)
     private String locationName;

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -14,8 +14,8 @@ public class DiaryRequestDTO {
         private String content;
         private LocalDateTime date;
 
-        private Double latitude;
-        private Double longitude;
+        private double latitude;
+        private double longitude;
         private String locationName;
 
     }
@@ -40,8 +40,8 @@ public class DiaryRequestDTO {
     @Getter
     public static class MapDTO {
         private Long userId;
-        private Double latitude;
-        private Double longitude;
+        private double latitude;
+        private double longitude;
     }
 
     @Getter

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -14,8 +14,8 @@ public class DiaryRequestDTO {
         private String content;
         private LocalDateTime date;
 
-        private String latitude;
-        private String longitude;
+        private Double latitude;
+        private Double longitude;
         private String locationName;
 
     }
@@ -40,8 +40,8 @@ public class DiaryRequestDTO {
     @Getter
     public static class MapDTO {
         private Long userId;
-        private String latitude;
-        private String longitude;
+        private Double latitude;
+        private Double longitude;
     }
 
     @Getter


### PR DESCRIPTION
## #️⃣연관된 이슈
> #28

## 📝작업 내용
> diaries entity의 위도 경도 column의 type을 String에서 double로 변경

## 🔎코드 설명
> diaries entity의 위도 경도 column의 type을 String에서 double로 변경
> Java에서 double을 사용해 소수를 표현한다면 소수점 약 15자리부터 오차가 발생할 수 있기에 double로도 위도, 경도를 표현하기에 충분해보임. BigDecimal vs double논의 필요해보임.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> BigDecimal vs double논의 필요해보임.

## 비고 (Optional)
> 위도 경도 타입관련 링크
> https://seoarc.tistory.com/123
