### PR TITLE
[Feat] 일기 삭제 API 구현 및 s3 객체 삭제

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -23,6 +23,12 @@ public enum ErrorStatus implements BaseErrorCode {
     // Article Error
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
 
+    // Diary Error
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY4001", "일기가 없습니다"),
+
+    // Category Error
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4001","카테고리가 없습니다."),
+
     // For test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트");
 

--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -23,9 +23,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 일기 관련 응답 2000
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_2001", "해당하는 일기가 존재하지 않습니다."),
+    DIARY_IS_NULL(HttpStatus.BAD_REQUEST, "DIARY_2002", "일기는 필수 입니다."),
 
     // 일기 카테고리 관련 응답 3000
-    DIARY_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_CATEGORY_3001", "해당하는 일기 카테고리가 존재하지 않습니다.");
+    DIARY_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_CATEGORY_3001", "해당하는 일기 카테고리가 존재하지 않습니다."),
+    DIARY_CATEGORY_IS_NULL(HttpStatus.BAD_REQUEST, "DIARY_CATEGORY_3002", "일기 카테고리는 필수 입니다.");
 
     // ~~~ 관련 응답 ....
 

--- a/src/main/java/TtattaBackend/ttatta/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/TtattaBackend/ttatta/aws/s3/AmazonS3Manager.java
@@ -45,6 +45,10 @@ public class AmazonS3Manager{
         return amazonConfig.getDiaryPath() + '/' + uuid.getUuid();
     }
 
+    public String getUuidByUrl(String pictureUrl) {
+        return pictureUrl.substring(pictureUrl.lastIndexOf("/") + 1);
+    }
+
     public void deleteFile(String keyName) {
         try {
             amazonS3.deleteObject(new DeleteObjectRequest(amazonConfig.getBucket(), keyName));

--- a/src/main/java/TtattaBackend/ttatta/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/TtattaBackend/ttatta/aws/s3/AmazonS3Manager.java
@@ -4,6 +4,7 @@ import TtattaBackend.ttatta.config.AmazonConfig;
 import TtattaBackend.ttatta.domain.Uuid;
 import TtattaBackend.ttatta.repository.UuidRepository;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
@@ -42,5 +43,13 @@ public class AmazonS3Manager{
 
     public String generateDiaryKeyName(Uuid uuid) {
         return amazonConfig.getDiaryPath() + '/' + uuid.getUuid();
+    }
+
+    public void deleteFile(String keyName) {
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(amazonConfig.getBucket(), keyName));
+        } catch (Exception e) {
+            log.error("error at AmazonS3Manager deleteFile : {}", (Object) e.getStackTrace());
+        }
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryPhotosRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryPhotosRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 @Repository
 public interface DiaryPhotosRepository extends JpaRepository<DiaryPhotos, Long> {
-    List<DiaryPhotos> findByDiaries_Id(Long diaryId);
+    DiaryPhotos findByDiaries_Id(Long diaryId);
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryPhotosRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryPhotosRepository.java
@@ -2,6 +2,11 @@ package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.DiaryPhotos;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface DiaryPhotosRepository extends JpaRepository<DiaryPhotos, Long> {
+    List<DiaryPhotos> findByDiaries_Id(Long diaryId);
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/UuidRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/UuidRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UuidRepository extends JpaRepository<Uuid, Long> {
+    Uuid findByUuid(String uuid);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoService.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface DiaryPhotoService {
     Diaries save(DiaryRequestDTO.PostDTO postDTO, List<MultipartFile> diaryPhotos);
+    void deleteDiary(DiaryRequestDTO.DeleteDTO request, Long diaryId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoService.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 public interface DiaryPhotoService {
     Diaries save(DiaryRequestDTO.PostDTO postDTO, List<MultipartFile> diaryPhotos);
-    void deleteDiary(DiaryRequestDTO.DeleteDTO request, Long diaryId);
+    void delete(Long diaryId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoServiceImpl.java
@@ -6,13 +6,13 @@ import TtattaBackend.ttatta.converter.DiaryConverter;
 import TtattaBackend.ttatta.domain.*;
 import TtattaBackend.ttatta.repository.*;
 import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.USER_NOT_FOUND;
@@ -60,17 +60,23 @@ public class DiaryPhotoServiceImpl implements DiaryPhotoService{
    }
 
    @Override
+   @Transactional
     public void deleteDiary(DiaryRequestDTO.DeleteDTO request, Long diaryId) {
         Users user = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
 
-       Diaries diaries = diaryRepository.findById(diaryId)
-               .orElseThrow (() -> new RuntimeException("Diary not found"));
+        Diaries diaries = diaryRepository.findById(diaryId)
+                .orElseThrow (() -> new RuntimeException("Diary not found"));
 
         List<DiaryPhotos> diaryPhotos = diaryPhotosRepository.findByDiaries_Id(diaries.getId());
 
         for (DiaryPhotos diaryPhoto : diaryPhotos) {
-           s3Manager.deleteFile(diaryPhoto.getImageUrl());
+            String savedUuid = s3Manager.getUuidByUrl(diaryPhoto.getImageUrl());
+
+            Uuid uuid = uuidRepository.findByUuid(savedUuid);
+            uuidRepository.delete(uuid);
+
+            s3Manager.deleteFile(s3Manager.generateDiaryKeyName(uuid));
         }
 
         diaryRepository.delete(diaries);

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoServiceImpl.java
@@ -15,7 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.UUID;
 
-import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.USER_NOT_FOUND;
+import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.*;
 
 @Slf4j
 @Service
@@ -36,9 +36,9 @@ public class DiaryPhotoServiceImpl implements DiaryPhotoService{
     @Override
     public Diaries save(DiaryRequestDTO.PostDTO request, List<MultipartFile> diaryPhotos) {
         Users user = userRepository.findById(request.getUserId())
-                .orElseThrow (() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
         DiaryCategories diaryCategories = diaryCategoryRepository.findById(request.getDiaryCategoryId())
-                .orElseThrow (() -> new RuntimeException("Category not found"));
+                .orElseThrow(() -> new ExceptionHandler(CATEGORY_NOT_FOUND));
 
         Diaries diaries = DiaryConverter.toDiaries(request);
 
@@ -64,20 +64,17 @@ public class DiaryPhotoServiceImpl implements DiaryPhotoService{
     public void deleteDiary(DiaryRequestDTO.DeleteDTO request, Long diaryId) {
         Users user = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
-
         Diaries diaries = diaryRepository.findById(diaryId)
-                .orElseThrow (() -> new RuntimeException("Diary not found"));
+                .orElseThrow(() -> new ExceptionHandler(DIARY_NOT_FOUND));
 
-        List<DiaryPhotos> diaryPhotos = diaryPhotosRepository.findByDiaries_Id(diaries.getId());
+        DiaryPhotos diaryPhoto = diaryPhotosRepository.findByDiaries_Id(diaries.getId());
 
-        for (DiaryPhotos diaryPhoto : diaryPhotos) {
-            String savedUuid = s3Manager.getUuidByUrl(diaryPhoto.getImageUrl());
+        String savedUuid = s3Manager.getUuidByUrl(diaryPhoto.getImageUrl());
 
-            Uuid uuid = uuidRepository.findByUuid(savedUuid);
-            uuidRepository.delete(uuid);
+        Uuid uuid = uuidRepository.findByUuid(savedUuid);
+        uuidRepository.delete(uuid);
 
-            s3Manager.deleteFile(s3Manager.generateDiaryKeyName(uuid));
-        }
+        s3Manager.deleteFile(s3Manager.generateDiaryKeyName(uuid));
 
         diaryRepository.delete(diaries);
 

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoServiceImpl.java
@@ -1,17 +1,23 @@
 package TtattaBackend.ttatta.service.DiaryService;
 
+import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
 import TtattaBackend.ttatta.aws.s3.AmazonS3Manager;
 import TtattaBackend.ttatta.converter.DiaryConverter;
 import TtattaBackend.ttatta.domain.*;
 import TtattaBackend.ttatta.repository.*;
 import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.USER_NOT_FOUND;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DiaryPhotoServiceImpl implements DiaryPhotoService{
@@ -52,4 +58,23 @@ public class DiaryPhotoServiceImpl implements DiaryPhotoService{
 
         return savedDiaries;
    }
+
+   @Override
+    public void deleteDiary(DiaryRequestDTO.DeleteDTO request, Long diaryId) {
+        Users user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+       Diaries diaries = diaryRepository.findById(diaryId)
+               .orElseThrow (() -> new RuntimeException("Diary not found"));
+
+        List<DiaryPhotos> diaryPhotos = diaryPhotosRepository.findByDiaries_Id(diaries.getId());
+
+        for (DiaryPhotos diaryPhoto : diaryPhotos) {
+           s3Manager.deleteFile(diaryPhoto.getImageUrl());
+        }
+
+        diaryRepository.delete(diaries);
+
+   }
+
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoServiceImpl.java
@@ -38,7 +38,7 @@ public class DiaryPhotoServiceImpl implements DiaryPhotoService{
         Users user = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
         DiaryCategories diaryCategories = diaryCategoryRepository.findById(request.getDiaryCategoryId())
-                .orElseThrow(() -> new ExceptionHandler(CATEGORY_NOT_FOUND));
+                .orElseThrow(() -> new ExceptionHandler(DIARY_CATEGORY_NOT_FOUND));
 
         Diaries diaries = DiaryConverter.toDiaries(request);
 

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryPhotoServiceImpl.java
@@ -35,10 +35,8 @@ public class DiaryPhotoServiceImpl implements DiaryPhotoService{
 
     @Override
     public Diaries save(DiaryRequestDTO.PostDTO request, List<MultipartFile> diaryPhotos) {
-        Users user = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
-        DiaryCategories diaryCategories = diaryCategoryRepository.findById(request.getDiaryCategoryId())
-                .orElseThrow(() -> new ExceptionHandler(DIARY_CATEGORY_NOT_FOUND));
+        Users user = userRepository.findById(request.getUserId()).get();
+        DiaryCategories diaryCategories = diaryCategoryRepository.findById(request.getDiaryCategoryId()).get();
 
         Diaries diaries = DiaryConverter.toDiaries(request);
 
@@ -61,9 +59,7 @@ public class DiaryPhotoServiceImpl implements DiaryPhotoService{
 
    @Override
    @Transactional
-    public void deleteDiary(DiaryRequestDTO.DeleteDTO request, Long diaryId) {
-        Users user = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+    public void delete(Long diaryId) {
         Diaries diaries = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new ExceptionHandler(DIARY_NOT_FOUND));
 

--- a/src/main/java/TtattaBackend/ttatta/validation/annotation/ExistDiary.java
+++ b/src/main/java/TtattaBackend/ttatta/validation/annotation/ExistDiary.java
@@ -1,0 +1,18 @@
+package TtattaBackend.ttatta.validation.annotation;
+
+import TtattaBackend.ttatta.validation.validator.ExistDiaryValidator;
+import TtattaBackend.ttatta.validation.validator.ExistUserValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ExistDiaryValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistDiary {
+    String message() default "해당하는 일기가 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/TtattaBackend/ttatta/validation/annotation/ExistDiaryCategory.java
+++ b/src/main/java/TtattaBackend/ttatta/validation/annotation/ExistDiaryCategory.java
@@ -1,0 +1,18 @@
+package TtattaBackend.ttatta.validation.annotation;
+
+import TtattaBackend.ttatta.validation.validator.ExistDiaryCategoryValidator;
+import TtattaBackend.ttatta.validation.validator.ExistUserValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ExistDiaryCategoryValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistDiaryCategory {
+    String message() default "해당하는 일기 카테고리가 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/TtattaBackend/ttatta/validation/validator/ExistDiaryCategoryValidator.java
+++ b/src/main/java/TtattaBackend/ttatta/validation/validator/ExistDiaryCategoryValidator.java
@@ -1,0 +1,43 @@
+package TtattaBackend.ttatta.validation.validator;
+
+import TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus;
+import TtattaBackend.ttatta.repository.DiaryCategoryRepository;
+import TtattaBackend.ttatta.validation.annotation.ExistDiaryCategory;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ExistDiaryCategoryValidator implements ConstraintValidator<ExistDiaryCategory, Long> {
+
+    private final DiaryCategoryRepository diaryCategoryRepository;
+
+    @Override
+    public void initialize(ExistDiaryCategory constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long diaryCategoryId, ConstraintValidatorContext context) {
+        ErrorStatus errorStatus;
+
+        boolean isValid;
+
+        if(diaryCategoryId == null) {
+            errorStatus = ErrorStatus.DIARY_CATEGORY_IS_NULL;
+            isValid = false;
+        } else {
+            errorStatus = ErrorStatus.DIARY_CATEGORY_NOT_FOUND;
+            isValid = diaryCategoryRepository.findById(diaryCategoryId).isPresent();
+        }
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(errorStatus.getMessage()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/validation/validator/ExistDiaryValidator.java
+++ b/src/main/java/TtattaBackend/ttatta/validation/validator/ExistDiaryValidator.java
@@ -1,0 +1,43 @@
+package TtattaBackend.ttatta.validation.validator;
+
+import TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus;
+import TtattaBackend.ttatta.repository.DiaryRepository;
+import TtattaBackend.ttatta.validation.annotation.ExistDiary;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ExistDiaryValidator implements ConstraintValidator<ExistDiary, Long> {
+
+    private final DiaryRepository diaryRepository;
+
+    @Override
+    public void initialize(ExistDiary constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long diaryId, ConstraintValidatorContext context) {
+        ErrorStatus errorStatus;
+
+        boolean isValid;
+
+        if(diaryId == null) {
+            errorStatus = ErrorStatus.DIARY_IS_NULL;
+            isValid = false;
+        } else {
+            errorStatus = ErrorStatus.DIARY_NOT_FOUND;
+            isValid = diaryRepository.findById(diaryId).isPresent();
+        }
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(errorStatus.getMessage()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -34,7 +34,7 @@ public class DiaryController {
     @PostMapping(value = "/post", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ApiResponse<DiaryResponseDTO.PostResultDTO> diarySave(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                                                           @RequestPart @Valid DiaryRequestDTO.PostDTO request,
-                                                                 @RequestPart("image") @Valid List<MultipartFile> diaryPhotos){
+                                                                 @RequestPart("image") List<MultipartFile> diaryPhotos){
         Diaries diaries = diaryPhotoService.save(request, diaryPhotos);
 
         return ApiResponse.onSuccess(
@@ -49,9 +49,9 @@ public class DiaryController {
                     """
     )
     @DeleteMapping("/delete/{diaryId}")
-    public ApiResponse<Object> deleteDiary(@PathVariable Long diaryId,
+    public ApiResponse<Object> deleteDiary(@PathVariable  Long diaryId,
                                            @RequestBody @Valid DiaryRequestDTO.DeleteDTO request) {
-        diaryPhotoService.deleteDiary(request,diaryId);
+        diaryPhotoService.delete(diaryId);
 
         return ApiResponse.onSuccess("");
     }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -34,7 +34,7 @@ public class DiaryController {
     @PostMapping(value = "/post", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ApiResponse<DiaryResponseDTO.PostResultDTO> diarySave(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                                                           @RequestPart @Valid DiaryRequestDTO.PostDTO request,
-                                                                 @RequestPart("image") List<MultipartFile> diaryPhotos){
+                                                                 @RequestPart("image") @Valid List<MultipartFile> diaryPhotos){
         Diaries diaries = diaryPhotoService.save(request, diaryPhotos);
 
         return ApiResponse.onSuccess(

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -51,7 +51,9 @@ public class DiaryController {
     @DeleteMapping("/delete/{diaryId}")
     public ApiResponse<Object> deleteDiary(@PathVariable Long diaryId,
                                            @RequestBody @Valid DiaryRequestDTO.DeleteDTO request) {
-        return null;
+        diaryPhotoService.deleteDiary(request,diaryId);
+
+        return ApiResponse.onSuccess("");
     }
 
     @Operation(summary = "일기 수정",

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -1,5 +1,6 @@
 package TtattaBackend.ttatta.web.dto;
 
+import TtattaBackend.ttatta.validation.annotation.ExistDiaryCategory;
 import TtattaBackend.ttatta.validation.annotation.ExistUser;
 import lombok.Getter;
 
@@ -12,6 +13,7 @@ public class DiaryRequestDTO {
         @ExistUser
         private Long userId;
 
+        @ExistDiaryCategory
         private Long diaryCategoryId;
         private String content;
         private LocalDateTime date;
@@ -24,6 +26,7 @@ public class DiaryRequestDTO {
 
     @Getter
     public static class DeleteDTO {
+        @ExistUser
         private Long userId;
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #26 

## 📝작업 내용
> 작성된 일기를 삭제하는 코드 구현

## 🔎코드 설명
> deleteDiary 메서드
> diaryId로 diaryPhoto 찾기
> getUuidByUrl -> ImageUrl로 uuid 반환
> 저장되어있는 Uuid 삭제, s3객체 삭제, db 사진 삭제

> 예외 처리 코드 변경
> DTO는 @Valid가 되는데 path variable에 들어가는 diaryId는 그렇게 처리가 안된다고 해서
> 일단 그 부분만 service에서 예외처리 해뒀습니다 !

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 현재는 사진 한 장 기준으로 코드 구현을 해놨고, 수정하기 협의되면 추후에 수정하겠습니다 :)

## 비고 (Optional)
> x
