### PR TITLE
[Feat] 카테고리 삭제 API

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/domain/DiaryCategories.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/DiaryCategories.java
@@ -34,7 +34,7 @@ public class DiaryCategories extends BaseEntity {
     private CategoryColor color;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "users_id")
+    @JoinColumn(name = "user_id")
     private Users users;
 
     @OneToMany(mappedBy = "diaryCategories", cascade = CascadeType.ALL)

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryCategoryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryCategoryRepository.java
@@ -2,6 +2,10 @@ package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.DiaryCategories;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface DiaryCategoryRepository extends JpaRepository<DiaryCategories, Long> {
+    Optional<DiaryCategories> findByNameAndId(@Param("name")String name, @Param("userId")Long userId);
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryCategoryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryCategoryRepository.java
@@ -1,11 +1,13 @@
 package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.DiaryCategories;
+import TtattaBackend.ttatta.validation.annotation.ExistDiaryCategory;
+import TtattaBackend.ttatta.validation.annotation.ExistUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface DiaryCategoryRepository extends JpaRepository<DiaryCategories, Long> {
-    Optional<DiaryCategories> findByNameAndId(@Param("name")String name, @Param("userId")Long userId);
+    Optional<DiaryCategories> findByNameAndId(@ExistDiaryCategory @Param("name")String name, @ExistUser @Param("userId")Long userId);
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -3,8 +3,15 @@ package TtattaBackend.ttatta.repository;
 import TtattaBackend.ttatta.domain.Diaries;
 import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diaries, Long> {
+    @Modifying
+    @Query("UPDATE Diaries d SET d.diaryCategories.id = :targetCategoryId WHERE d.diaryCategories.id = :sourceCategoryId")
+    void updateCategoryForDiaries(@Param("sourceCategoryId") Long sourceCategoryId,
+                                  @Param("targetCategoryId") Long targetCategoryId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryCategoryService/DiaryCategoryCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryCategoryService/DiaryCategoryCommandService.java
@@ -7,4 +7,5 @@ public interface DiaryCategoryCommandService {
     DiaryCategories createCategory(DiaryCategoryRequestDTO.CreateCategoryDTO request);
     DiaryCategories modifyCategory(Long categoryId, DiaryCategoryRequestDTO.ModifyCategoryDTO request);
     void deleteAllCategory(Long categoryId, DiaryCategoryRequestDTO.DeleteCategoryDTO request);
+    void deleteCategory(Long categoryId, DiaryCategoryRequestDTO.DeleteCategoryDTO request);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryCategoryService/DiaryCategoryCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryCategoryService/DiaryCategoryCommandServiceImpl.java
@@ -8,6 +8,7 @@ import TtattaBackend.ttatta.domain.DiaryCategories;
 import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.domain.enums.CategoryColor;
 import TtattaBackend.ttatta.repository.DiaryCategoryRepository;
+import TtattaBackend.ttatta.repository.DiaryRepository;
 import TtattaBackend.ttatta.repository.UserRepository;
 import TtattaBackend.ttatta.web.dto.DiaryCategoryRequestDTO;
 import jakarta.transaction.Transactional;
@@ -22,6 +23,7 @@ public class DiaryCategoryCommandServiceImpl implements DiaryCategoryCommandServ
     private final DiaryCategoryRepository categoryRepository;
     private final UserRepository userRepository;
     private final DiaryCategoryRepository diaryCategoryRepository;
+    private final DiaryRepository diaryRepository;
 
 
     @Override
@@ -52,8 +54,25 @@ public class DiaryCategoryCommandServiceImpl implements DiaryCategoryCommandServ
     public void deleteAllCategory(Long categoryId, DiaryCategoryRequestDTO.DeleteCategoryDTO request) {
         DiaryCategories diaryCategory = diaryCategoryRepository.findById(categoryId)
                 .orElseThrow();
-
         diaryCategoryRepository.delete(diaryCategory);
+    }
+
+    @Override
+    @Transactional
+    public void deleteCategory(Long categoryId, DiaryCategoryRequestDTO.DeleteCategoryDTO request) {
+        Users user = userRepository.findById(request.getUserId())
+                .orElseThrow();
+
+        DiaryCategories diaryCategoryToDelete = diaryCategoryRepository.findById(categoryId)
+                .orElseThrow();
+
+        DiaryCategories defaultCategory = diaryCategoryRepository.findByNameAndId("일상", user.getId())
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus.DIARY_CATEGORY_NOT_FOUND));
+
+        diaryRepository.updateCategoryForDiaries(diaryCategoryToDelete.getId(), defaultCategory.getId());
+
+
+        diaryCategoryRepository.delete(diaryCategoryToDelete);
     }
 
     private void verifyCategoryColor(String categoryColor) {

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryCategoryService/DiaryCategoryCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryCategoryService/DiaryCategoryCommandServiceImpl.java
@@ -67,7 +67,7 @@ public class DiaryCategoryCommandServiceImpl implements DiaryCategoryCommandServ
                 .orElseThrow();
 
         DiaryCategories defaultCategory = diaryCategoryRepository.findByNameAndId("일상", user.getId())
-                .orElseThrow(() -> new ExceptionHandler(ErrorStatus.DIARY_CATEGORY_NOT_FOUND));
+                .orElseThrow();
 
         diaryRepository.updateCategoryForDiaries(diaryCategoryToDelete.getId(), defaultCategory.getId());
 

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryCategoryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryCategoryController.java
@@ -66,7 +66,8 @@ public class DiaryCategoryController {
     )
 
     @DeleteMapping("/{categoryId}")
-    public ApiResponse<DiaryCategoryResponseDTO.DeleteAllCategoryResultDTO> deleteAll(@PathVariable Long categoryId, @RequestBody @Valid DiaryCategoryRequestDTO.DeleteAllCategoryDTO request) {
+    public ApiResponse<Object> deleteAll(@PathVariable @ExistDiaryCategory Long categoryId, @RequestBody @Valid DiaryCategoryRequestDTO.DeleteCategoryDTO request) {
+        diaryCategoryCommandService.deleteCategory(categoryId,request);
         return null;
     }
 

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryCategoryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryCategoryRequestDTO.java
@@ -29,11 +29,13 @@ public class DiaryCategoryRequestDTO {
 
     @Getter
     public static class DeleteCategoryDTO {
+        @ExistUser
         Long userId;
     }
 
     @Getter
     public static class DeleteAllCategoryDTO {
+        @ExistUser
         Long userId;
     }
 


### PR DESCRIPTION
카테고리 삭제 시 해당 카테고리에 있는 일기는 모두 "일상"카테고리로 옮기고, 카테고린는 삭제

## #️⃣연관된 이슈
> #40 

## 📝작업 내용
> 카테고리 삭제 API 구현

## 🔎코드 설명
> 

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> Swagger 테스트 완료
