### PR TITLE
[Feat] 일반 로그인 성공이후 jwt토큰(accessToken) 발급 및 api요청 시 jwt토큰 검증 처리 기능 spring security와 함께 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,14 @@ dependencies {
 
 	//s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	//Jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// GSON
+	implementation 'com.google.code.gson:gson:2.10.1'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 
 	// GSON
 	implementation 'com.google.code.gson:gson:2.10.1'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -32,7 +32,8 @@ public enum ErrorStatus implements BaseErrorCode {
     // 일기 카테고리 관련 응답 4000
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "TOKEN_4001", "토큰이 전달되지 않았습니다."),
     INVALID_TOKEN_PREFIX(HttpStatus.NOT_FOUND, "TOKEN_4002", "BEARER 로 시작하지 않는 올바르지 않은 토큰 형식입니다."),
-    TOKEN_ERROR(HttpStatus.NOT_FOUND, "TOKEN_4003", "토큰관련 에러가 발생했습니다.");
+    TOKEN_ERROR(HttpStatus.NOT_FOUND, "TOKEN_4003", "토큰관련 에러가 발생했습니다."),
+    REFRESHTOKEN_NOT_EQUAL(HttpStatus.NOT_FOUND, "TOKEN_4004", "refresh token이 일치하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -27,10 +27,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 일기 카테고리 관련 응답 3000
     DIARY_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_CATEGORY_3001", "해당하는 일기 카테고리가 존재하지 않습니다."),
-    DIARY_CATEGORY_IS_NULL(HttpStatus.BAD_REQUEST, "DIARY_CATEGORY_3002", "일기 카테고리는 필수 입니다.");
+    DIARY_CATEGORY_IS_NULL(HttpStatus.BAD_REQUEST, "DIARY_CATEGORY_3002", "일기 카테고리는 필수 입니다."),
 
-    // ~~~ 관련 응답 ....
-
+    // 일기 카테고리 관련 응답 4000
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "TOKEN_4001", "토큰이 전달되지 않았습니다."),
+    INVALID_TOKEN_PREFIX(HttpStatus.NOT_FOUND, "TOKEN_4002", "BEARER 로 시작하지 않는 올바르지 않은 토큰 형식입니다."),
+    TOKEN_ERROR(HttpStatus.NOT_FOUND, "TOKEN_4003", "토큰관련 에러가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/TtattaBackend/ttatta/config/RedisConfig.java
+++ b/src/main/java/TtattaBackend/ttatta/config/RedisConfig.java
@@ -1,0 +1,17 @@
+package TtattaBackend.ttatta.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        return redisTemplate;
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/config/SwaggerConfig.java
+++ b/src/main/java/TtattaBackend/ttatta/config/SwaggerConfig.java
@@ -19,16 +19,25 @@ public class SwaggerConfig {
                 .description("따따 백엔드 API 명세서")
                 .version("1.0.0");
 
-        String jwtSchemeName = "JWT TOKEN";
+        String jwtSchemeName = "JWT access token";
+        String refreshKey = "JWT refresh token";
         // API 요청헤더에 인증정보 포함
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList(jwtSchemeName)
+                .addList(refreshKey);
         // SecuritySchemes 등록
         Components components = new Components()
                 .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
                         .name(jwtSchemeName)
                         .type(SecurityScheme.Type.HTTP) // HTTP 방식
                         .scheme("bearer")
-                        .bearerFormat("JWT"));
+                        .bearerFormat("JWT")
+                )
+                .addSecuritySchemes(refreshKey, new SecurityScheme()
+                        .name("RefreshToken")
+                        .type(SecurityScheme.Type.APIKEY)
+                        .in(SecurityScheme.In.HEADER)
+                );
 
         return new OpenAPI()
                 .addServersItem(new Server().url("/"))

--- a/src/main/java/TtattaBackend/ttatta/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/TtattaBackend/ttatta/config/security/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import TtattaBackend.ttatta.jwt.JwtUtils;
 import TtattaBackend.ttatta.jwt.exception.CustomExpiredJwtException;
 import TtattaBackend.ttatta.jwt.exception.CustomJwtException;
 import com.google.gson.Gson;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -40,6 +42,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 //            "/index.html"
     };
     private final JwtUtils jwtUtils;
+    private final RedisTemplate<String, String> redisTemplate;
 
     private static void checkAuthorizationHeader(String header) {
         if(header == null) {
@@ -60,7 +63,31 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         log.info("--------------------------- JwtVerifyFilter ---------------------------");
 
+        String requestUri = request.getRequestURI();
         String authHeader = request.getHeader(jwtHeader);
+        String refreshToken = request.getHeader("refreshToken");
+
+        // 특정 경로에서만 Refresh Token 처리
+        if ("/users/refresh".equals(requestUri)) { // if문 마지막에 return하지 말고 refresh token검증하는 로직을 service로 옮겨야 하나???
+            if (refreshToken != null) {
+                try {
+                    // access token 검증
+                    checkAuthorizationHeader(authHeader);   // header 가 올바른 형식인지 체크
+                    String token = JwtUtils.getTokenFromHeader(authHeader);
+                    Claims claims = jwtUtils.validateTokenOnlySignature(token); // 토큰 검증
+                    Authentication authentication = jwtUtils.getAuthentication(token); // 사용자 인증 정보 생성
+                    SecurityContextHolder.getContext().setAuthentication(authentication); // 사용자 인증 정보 저장
+                    // refresh token 검증
+                    jwtUtils.validateRefreshToken(refreshToken); // 토큰 검증
+                    filterChain.doFilter(request, response);    // 다음 필터로 이동
+                } catch (Exception e) {
+                    Gson gson = new Gson();
+                    String json = "";
+                    json = gson.toJson(Map.of("error", e.getMessage()));
+                }
+            }
+            return;
+        }
 
         try {
             checkAuthorizationHeader(authHeader);   // header 가 올바른 형식인지 체크

--- a/src/main/java/TtattaBackend/ttatta/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/TtattaBackend/ttatta/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,91 @@
+package TtattaBackend.ttatta.config.security;
+
+import TtattaBackend.ttatta.jwt.JwtUtils;
+import TtattaBackend.ttatta.jwt.exception.CustomExpiredJwtException;
+import TtattaBackend.ttatta.jwt.exception.CustomJwtException;
+import com.google.gson.Gson;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.PatternMatchUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j //???
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Value("${jwt.JWT_HEADER}")
+    private String jwtHeader;
+    private static final String[] whitelist = {
+            "/users/signup",
+            "/users/signup/**",
+            "/users/signin",
+            "/users/signin/**",
+            "/users/testuser",
+            "/swagger-ui/**",
+            "/v3/**"
+//            "/refresh", "/",
+//            "/index.html"
+    };
+    private final JwtUtils jwtUtils;
+
+    private static void checkAuthorizationHeader(String header) {
+        if(header == null) {
+            throw new CustomJwtException("토큰이 전달되지 않았습니다");
+        } else if (!header.startsWith("Bearer ")) {
+            throw new CustomJwtException("Bearer 로 시작하지 않는 올바르지 않은 토큰 형식입니다");
+        }
+    }
+
+    // 필터를 거치지 않을 URL(로그인, 회원가입) 을 설정하고, true 를 return 하면 현재 필터를 건너뛰고 다음 필터로 이동
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String requestURI = request.getRequestURI();
+        return PatternMatchUtils.simpleMatch(whitelist, requestURI);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("--------------------------- JwtVerifyFilter ---------------------------");
+
+        String authHeader = request.getHeader(jwtHeader);
+
+        try {
+            checkAuthorizationHeader(authHeader);   // header 가 올바른 형식인지 체크
+            String token = JwtUtils.getTokenFromHeader(authHeader);
+            jwtUtils.validateToken(token); // 토큰 검증
+            jwtUtils.isExpired(token); // 토큰 만료 검증
+
+            Authentication authentication = jwtUtils.getAuthentication(token); // 사용자 인증 정보 생성
+            log.info("authentication = {}", authentication);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            filterChain.doFilter(request, response);    // 다음 필터로 이동
+        } catch (Exception e) {
+            Gson gson = new Gson();
+            String json = "";
+            if (e instanceof CustomExpiredJwtException) {
+                json = gson.toJson(Map.of("Token_Expired", e.getMessage()));
+            } else {
+                json = gson.toJson(Map.of("error", e.getMessage()));
+            }
+
+            response.setContentType("application/json; charset=UTF-8");
+            PrintWriter printWriter = response.getWriter();
+            printWriter.println(json);
+            printWriter.close();
+        }
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/config/security/SecurityConfig.java
+++ b/src/main/java/TtattaBackend/ttatta/config/security/SecurityConfig.java
@@ -1,24 +1,38 @@
 package TtattaBackend.ttatta.config.security;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable) // 추가해주어야함.
+                // 폼 로그인 비활성화
+                .formLogin(AbstractHttpConfigurer::disable)
+                // HTTP Basic 인증 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션을 Stateless로 설정
                 .authorizeHttpRequests((requests) -> requests
-                        .requestMatchers("/**").permitAll());
+                        .requestMatchers("/**").permitAll())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
 //                .authorizeHttpRequests((requests) -> requests
 //                        .requestMatchers("/", "/home", "/signup", "/css/**").permitAll()
 //                        .requestMatchers("/admin/**").hasRole("ADMIN")

--- a/src/main/java/TtattaBackend/ttatta/config/security/SecurityUtil.java
+++ b/src/main/java/TtattaBackend/ttatta/config/security/SecurityUtil.java
@@ -11,7 +11,7 @@ public class SecurityUtil {
 
     // SecurityContext 에 유저 정보가 저장되는 시점
     // Request 가 들어올 때 JwtAuthenticationFilter 의 doFilterInternal 에서 저장
-    public static Long getCurrentMemberId() {
+    public static Long getCurrentUserId() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || authentication.getName() == null) {

--- a/src/main/java/TtattaBackend/ttatta/config/security/SecurityUtil.java
+++ b/src/main/java/TtattaBackend/ttatta/config/security/SecurityUtil.java
@@ -1,0 +1,23 @@
+package TtattaBackend.ttatta.config.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Slf4j
+public class SecurityUtil {
+
+    private SecurityUtil() { }
+
+    // SecurityContext 에 유저 정보가 저장되는 시점
+    // Request 가 들어올 때 JwtAuthenticationFilter 의 doFilterInternal 에서 저장
+    public static Long getCurrentMemberId() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getName() == null) {
+            throw  new RuntimeException("Security Context 에 인증 정보가 없습니다.");
+        }
+
+        return Long.parseLong(authentication.getName());
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -23,9 +23,10 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.UserSignInResultDTO toUserSignInResultDTO(Users users, String accessToken) {
+    public static UserResponseDTO.UserSignInResultDTO toUserSignInResultDTO(Users users, String accessToken, String refreshToken) {
         return UserResponseDTO.UserSignInResultDTO.builder()
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .userId(users.getId())
                 .nickname(users.getNickname())
                 .loginType(users.getLoginType())

--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -23,8 +23,9 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.UserSignInResultDTO toUserSignInResultDTO(Users users) {
+    public static UserResponseDTO.UserSignInResultDTO toUserSignInResultDTO(Users users, String accessToken) {
         return UserResponseDTO.UserSignInResultDTO.builder()
+                .accessToken(accessToken)
                 .userId(users.getId())
                 .nickname(users.getNickname())
                 .loginType(users.getLoginType())

--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -34,11 +34,11 @@ public class UserConverter {
                 .build();
     }
 
-    // 미구현
-    public static UserResponseDTO.RefreshResultDTO toRefreshResultDTO(Users users) {
+    public static UserResponseDTO.RefreshResultDTO toRefreshResultDTO(Long userId, String accessToken, String refreshToken) {
         return UserResponseDTO.RefreshResultDTO.builder()
-                .userId(users.getId())
-                .refreshToken(users.getRefreshToken())
+                .userId(userId)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/TtattaBackend/ttatta/jwt/JwtUtils.java
+++ b/src/main/java/TtattaBackend/ttatta/jwt/JwtUtils.java
@@ -3,7 +3,9 @@ package TtattaBackend.ttatta.jwt;
 import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.jwt.exception.CustomExpiredJwtException;
 import TtattaBackend.ttatta.jwt.exception.CustomJwtException;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
@@ -69,11 +71,44 @@ public class JwtUtils {
                     .parseClaimsJws(token) // 파싱 및 검증, 실패 시 에러
                     .getBody();
         } catch(ExpiredJwtException expiredJwtException){
-            throw new CustomExpiredJwtException("토큰이 만료되었습니다", expiredJwtException);
+            throw new CustomExpiredJwtException("access token이 만료되었습니다", expiredJwtException);
         } catch(Exception e){
             throw new CustomJwtException("Error");
         }
         return claim;
+    }
+
+    public Claims validateTokenOnlySignature(String token) { // static 제거
+        Claims claims = null;
+        try {
+            SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+            claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token) // 파싱 및 검증, 실패 시 에러
+                    .getBody();
+        } catch(ExpiredJwtException expiredJwtException){
+            return claims;
+        } catch(Exception e){
+            throw new CustomJwtException("Error access token 검증 못함");
+        }
+        return claims;
+    }
+
+    public void validateRefreshToken(String token) { // static 제거
+        Map<String, Object> claim = null;
+        try {
+            SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+            claim = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token) // 파싱 및 검증, 실패 시 에러
+                    .getBody();
+        } catch(ExpiredJwtException expiredJwtException){
+            throw new CustomExpiredJwtException("refresh token이 만료되었습니다. 재로그인 해주세요.", expiredJwtException);
+        } catch(Exception e){
+            throw new CustomJwtException("Error");
+        }
     }
 
     // 토큰이 만료되었는지 판단하는 메서드

--- a/src/main/java/TtattaBackend/ttatta/jwt/JwtUtils.java
+++ b/src/main/java/TtattaBackend/ttatta/jwt/JwtUtils.java
@@ -1,0 +1,95 @@
+package TtattaBackend.ttatta.jwt;
+
+import TtattaBackend.ttatta.domain.Users;
+import TtattaBackend.ttatta.jwt.exception.CustomExpiredJwtException;
+import TtattaBackend.ttatta.jwt.exception.CustomJwtException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtils {
+
+    @Value("${jwt.secret}")
+    public String secretKey;
+
+    // 헤더에 "Bearer XXX" 형식으로 담겨온 토큰을 추출한다
+    public static String getTokenFromHeader(String header) {
+        return header.split(" ")[1];
+    }
+
+    public String generateToken(Map<String, Object> valueMap, int validTime) { // static 제거
+        SecretKey key = null;
+        try {
+            key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        } catch(Exception e){
+            throw new RuntimeException(e.getMessage());
+        }
+        return Jwts.builder()
+                .setHeader(Map.of("typ","JWT"))
+                .setClaims(valueMap)
+                .setIssuedAt(Date.from(ZonedDateTime.now().toInstant()))
+                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(validTime).toInstant()))
+                .signWith(key)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) { // context에 넣을 Authentication를 jwt의 userId를 넣어 생성 // static 제거
+        Map<String, Object> claims = validateToken(token);
+        System.out.println("userId type: " + (claims.get("userId") != null ? claims.get("userId").getClass().getName() : "null"));
+
+//        String email = (String) claims.get("email");
+        Long userId = ((Integer) claims.get("userId")).longValue();
+
+        return new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+    }
+
+    public Map<String, Object> validateToken(String token) { // static 제거
+        Map<String, Object> claim = null;
+        try {
+            SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+            claim = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token) // 파싱 및 검증, 실패 시 에러
+                    .getBody();
+        } catch(ExpiredJwtException expiredJwtException){
+            throw new CustomExpiredJwtException("토큰이 만료되었습니다", expiredJwtException);
+        } catch(Exception e){
+            throw new CustomJwtException("Error");
+        }
+        return claim;
+    }
+
+    // 토큰이 만료되었는지 판단하는 메서드
+    public boolean isExpired(String token) { // static 제거
+        try {
+            validateToken(token);
+        } catch (Exception e) {
+            return (e instanceof CustomExpiredJwtException);
+        }
+        return false;
+    }
+
+    // 토큰의 남은 만료시간 계산
+    public long tokenRemainTime(Integer expTime) { // static 제거
+        Date expDate = new Date((long) expTime * (1000));
+        long remainMs = expDate.getTime() - System.currentTimeMillis();
+        return remainMs / (1000 * 60);
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/jwt/exception/CustomExpiredJwtException.java
+++ b/src/main/java/TtattaBackend/ttatta/jwt/exception/CustomExpiredJwtException.java
@@ -1,0 +1,16 @@
+package TtattaBackend.ttatta.jwt.exception;
+
+import io.jsonwebtoken.ExpiredJwtException;
+
+public class CustomExpiredJwtException extends ExpiredJwtException {
+    private final String message;
+
+    public CustomExpiredJwtException(String message, ExpiredJwtException source) {
+        super(source.getHeader(), source.getClaims(), source.getMessage());
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/jwt/exception/CustomJwtException.java
+++ b/src/main/java/TtattaBackend/ttatta/jwt/exception/CustomJwtException.java
@@ -1,0 +1,7 @@
+package TtattaBackend.ttatta.jwt.exception;
+
+public class CustomJwtException extends RuntimeException {
+    public CustomJwtException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -2,11 +2,12 @@ package TtattaBackend.ttatta.service.UserService;
 
 import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
+import TtattaBackend.ttatta.web.dto.UserResponseDTO;
 
 public interface UserCommandService {
     Users createTestUser();
     Users signUp(UserRequestDTO.SignUpRequestDTO request);
-    Users signIn(UserRequestDTO.SignInRequestDTO request);
+    UserResponseDTO.UserSignInResultDTO signIn(UserRequestDTO.SignInRequestDTO request);
     Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request);    // 미구현
     Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
     Users refresh(String request);  // 미구현

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -8,9 +8,9 @@ public interface UserCommandService {
     Users createTestUser();
     Users signUp(UserRequestDTO.SignUpRequestDTO request);
     UserResponseDTO.UserSignInResultDTO signIn(UserRequestDTO.SignInRequestDTO request);
+    UserResponseDTO.RefreshResultDTO refresh(String refreshToken);
     Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request);    // 미구현
     Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
-    Users refresh(String request);  // 미구현
     Users getUserInfo(Long userId);
     Users updateUserInfo(Long userId, UserRequestDTO.UpdateRequestDTO request);
     void deleteUser(Long userId);

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -90,7 +90,7 @@ public class UserCommandServiceImpl implements UserCommandService {
         redisTemplate.opsForValue().set(user.getId().toString(), refreshToken);
         System.out.println("redis에 저장된 refreshToken: " + (String) redisTemplate.opsForValue().get(user.getId().toString()));
 
-        return UserConverter.toUserSignInResultDTO(user, accessToken);
+        return UserConverter.toUserSignInResultDTO(user, accessToken, refreshToken);
     }
 
     // 미구현

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -6,11 +6,14 @@ import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.domain.enums.Gender;
 import TtattaBackend.ttatta.domain.enums.LoginType;
 import TtattaBackend.ttatta.domain.enums.UserStatus;
+import TtattaBackend.ttatta.jwt.JwtUtils;
 import TtattaBackend.ttatta.repository.UserRepository;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
+import TtattaBackend.ttatta.web.dto.UserResponseDTO;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -19,6 +22,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.*;
 
@@ -27,9 +31,14 @@ import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.*;
 @Slf4j
 public class UserCommandServiceImpl implements UserCommandService {
 
+    @Value("${jwt.ACCESS_EXP_TIME}")
+    private int accessExpTime;
+    @Value("${jwt.REFRESH_EXP_TIME}")
+    private int refreshExpTime;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtUtils jwtUtils;
 
     @Override
     public Users createTestUser() {
@@ -60,14 +69,20 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     @Override
     @Transactional // ???
-    public Users signIn(UserRequestDTO.SignInRequestDTO request) {
+    public UserResponseDTO.UserSignInResultDTO signIn(UserRequestDTO.SignInRequestDTO request) {
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword());
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+//        SecurityContextHolder.getContext().setAuthentication(authentication); // 로그인을 한 후 인증 정보를 사용할 일은 없을 것 같다.
 
-        Users user = userRepository.findByUsername(authentication.getName()).orElse(null);
+        Users user = userRepository.findByUsername(authentication.getName()).orElseThrow();
 
-        return user;
+        // 인증 완료 후 jwt 생성
+        Map<String, Object> valueMap = Map.of(
+                "userId", user.getId()
+        );
+        String accessToken = jwtUtils.generateToken(valueMap, accessExpTime);
+
+        return UserConverter.toUserSignInResultDTO(user, accessToken);
     }
 
     // 미구현

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -1,6 +1,7 @@
 package TtattaBackend.ttatta.service.UserService;
 
 import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
+import TtattaBackend.ttatta.config.security.SecurityUtil;
 import TtattaBackend.ttatta.converter.UserConverter;
 import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.domain.enums.Gender;
@@ -25,6 +26,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.*;
 
@@ -81,16 +83,42 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         // 인증 완료 후 jwt토큰(accessToken) 생성
         Map<String, Object> valueMap = Map.of(
-                "userId", user.getId()
+                "userId", user.getId() // String으로 저장??? 그래서 SecurityUtil에서 Long으로 타입변환 해주나?
         );
         String accessToken = jwtUtils.generateToken(valueMap, accessExpTime);
 
         // 인증 완료 후 jwt토큰(refreshToken) 생성
         String refreshToken = jwtUtils.generateToken(Collections.emptyMap(), refreshExpTime);
-        redisTemplate.opsForValue().set(user.getId().toString(), refreshToken);
+        redisTemplate.opsForValue().set(user.getId().toString(), refreshToken, refreshExpTime, TimeUnit.MINUTES);
         System.out.println("redis에 저장된 refreshToken: " + (String) redisTemplate.opsForValue().get(user.getId().toString()));
 
         return UserConverter.toUserSignInResultDTO(user, accessToken, refreshToken);
+    }
+
+    @Override
+    public UserResponseDTO.RefreshResultDTO refresh(String refreshToken) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        String accessToken;
+        String newRefreshToken;
+
+        // 전달된 refresh token과 redis의 refresh token비교
+        String getUserIdFromRedis = redisTemplate.opsForValue().get(userId.toString());
+        System.out.println("userId: " + userId);
+        System.out.println("redis에서 가져온 refreshToken: " + getUserIdFromRedis);
+        if (refreshToken.equals(getUserIdFromRedis)) {
+            // 인증 완료 후 jwt토큰(accessToken) 생성
+            Map<String, Object> valueMap = Map.of(
+                    "userId", userId
+            );
+            accessToken = jwtUtils.generateToken(valueMap, accessExpTime);
+            // 인증 완료 후 jwt토큰(refreshToken) 생성
+            newRefreshToken = jwtUtils.generateToken(Collections.emptyMap(), refreshExpTime);
+            redisTemplate.opsForValue().set(userId.toString(), newRefreshToken, refreshExpTime, TimeUnit.MINUTES);
+        } else {
+            throw new ExceptionHandler(REFRESHTOKEN_NOT_EQUAL);
+        }
+
+        return UserConverter.toRefreshResultDTO(userId, accessToken, newRefreshToken);
     }
 
     // 미구현
@@ -103,13 +131,6 @@ public class UserCommandServiceImpl implements UserCommandService {
     // 미구현
     @Override
     public Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request) {
-        // 서비스 구현
-        return null;
-    }
-
-    // 미구현
-    @Override
-    public Users refresh(String request) {
         // 서비스 구현
         return null;
     }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -14,6 +14,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -22,6 +23,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.Map;
 
 import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.*;
@@ -39,6 +41,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtUtils jwtUtils;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Override
     public Users createTestUser() {
@@ -76,11 +79,16 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         Users user = userRepository.findByUsername(authentication.getName()).orElseThrow();
 
-        // 인증 완료 후 jwt 생성
+        // 인증 완료 후 jwt토큰(accessToken) 생성
         Map<String, Object> valueMap = Map.of(
                 "userId", user.getId()
         );
         String accessToken = jwtUtils.generateToken(valueMap, accessExpTime);
+
+        // 인증 완료 후 jwt토큰(refreshToken) 생성
+        String refreshToken = jwtUtils.generateToken(Collections.emptyMap(), refreshExpTime);
+        redisTemplate.opsForValue().set(user.getId().toString(), refreshToken);
+        System.out.println("redis에 저장된 refreshToken: " + (String) redisTemplate.opsForValue().get(user.getId().toString()));
 
         return UserConverter.toUserSignInResultDTO(user, accessToken);
     }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryCategoryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryCategoryController.java
@@ -7,6 +7,7 @@ import TtattaBackend.ttatta.service.DiaryCategoryService.DiaryCategoryCommandSer
 import TtattaBackend.ttatta.web.dto.DiaryCategoryRequestDTO;
 import TtattaBackend.ttatta.web.dto.DiaryCategoryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -17,9 +18,9 @@ import org.springframework.web.bind.annotation.*;
 public class DiaryCategoryController {
     private final DiaryCategoryCommandService diaryCategoryCommandService;
 
-    @Operation(summary = "카테고리 생성 api", description =
-            "새로운 카테고리를 생성할 때 사용하는 api 입니다.\n카테고리 이름과 색상, 사용자의 id 데이터를 넣어주시면 됩니다."
-    )
+    @Operation(
+            summary = "카테고리 생성 api",
+            description = "새로운 카테고리를 생성할 때 사용하는 api 입니다.\n카테고리 이름과 색상, 사용자의 id 데이터를 넣어주시면 됩니다.")
 
     @PostMapping("/")
     public ApiResponse<DiaryCategoryResponseDTO.CreateCategoryResultDTO> create (@RequestBody @Valid DiaryCategoryRequestDTO.CreateCategoryDTO request) {
@@ -27,8 +28,8 @@ public class DiaryCategoryController {
         return ApiResponse.onSuccess(DiaryCategoryConverter.toCreateCategoryResultDTO(diaryCategory));
     }
 
-    @Operation(summary = "카테고리 수정 api", description =
-            "카테고리를 수정할 때 사용하는 api 입니다.\n카테고리 이름과 색상, 사용자의 Id 데이터를 넣어주시면 됩니다. 카테고리 Id는 path parameter로 전달받습니다."
+    @Operation(summary = "카테고리 수정 api",
+            description = "카테고리를 수정할 a때 사용하는 api 입니다.\n카테고리 이름과 색상, 사용자의 Id 데이터를 넣어주시면 됩니다. 카테고리 Id는 path parameter로 전달받습니다."
     )
 
     @PatchMapping("/{categoryId}")

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -96,7 +96,7 @@ public class UserController {
         Users user = userCommandService.signInKakao(request);
         return ApiResponse.onSuccess(
                 UserConverter.toUserSignInResultDTO(
-                        user, null
+                        user, null, null
                 )
         );
     }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -70,6 +70,19 @@ public class UserController {
     }
 
     // 미구현
+    @Operation(summary = "토큰 갱신", description =
+            "# access token 갱신 API 입니다. access token과 refresh token을 header에 입력해주세요."
+    )
+    @PostMapping("/refresh")
+    public ApiResponse<UserResponseDTO.RefreshResultDTO> refreshToken(
+            @RequestHeader("RefreshToken") String refreshToken
+    ) {
+        return ApiResponse.onSuccess(
+                userCommandService.refresh(refreshToken)
+        );
+    }
+
+    // 미구현
     @Operation(summary = "카카오 회원가입", description =
             "# 카카오 회원가입 API 입니다."
     )
@@ -97,22 +110,6 @@ public class UserController {
         return ApiResponse.onSuccess(
                 UserConverter.toUserSignInResultDTO(
                         user, null, null
-                )
-        );
-    }
-
-    // 미구현
-    @Operation(summary = "토큰 갱신", description =
-            "# 토큰 갱신 API 입니다. 리프레시 토큰을 header에 입력해주세요."
-    )
-    @PostMapping("/refresh")
-    public ApiResponse<UserResponseDTO.RefreshResultDTO> refreshToken(
-            @RequestHeader("refreshToken") String refreshToken
-    ) {
-        Users user = userCommandService.refresh(refreshToken);
-        return ApiResponse.onSuccess(
-                UserConverter.toRefreshResultDTO(
-                        user
                 )
         );
     }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -52,11 +52,8 @@ public class UserController {
     public ApiResponse<UserResponseDTO.UserSignInResultDTO> signIn(
             @RequestBody @Valid UserRequestDTO.SignInRequestDTO request
     ) {
-        Users user = userCommandService.signIn(request);
         return ApiResponse.onSuccess(
-                UserConverter.toUserSignInResultDTO(
-                        user
-                )
+                userCommandService.signIn(request)
         );
     }
 
@@ -99,7 +96,7 @@ public class UserController {
         Users user = userCommandService.signInKakao(request);
         return ApiResponse.onSuccess(
                 UserConverter.toUserSignInResultDTO(
-                        user
+                        user, null
                 )
         );
     }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -18,6 +18,7 @@ public class UserResponseDTO {
     @AllArgsConstructor
     public static class UserSignInResultDTO {
         String accessToken;
+        String refreshToken;
         Long userId;
         String nickname;
         LoginType loginType;

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -44,8 +44,7 @@ public class UserResponseDTO {
     public static class CheckUsernameSameResultDTO {
         IsSame isSame;
     }
-  
-    // 미구현
+
     @Getter
     @Builder
     @NoArgsConstructor

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -17,6 +17,7 @@ public class UserResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UserSignInResultDTO {
+        String accessToken;
         Long userId;
         String nickname;
         LoginType loginType;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #30

## 📝작업 내용 1
> ### 일반 로그인 성공이후 jwt토큰(accessToken) 발급 spring security와 함께 구현
> ### api요청 시 jwt토큰(accessToken) 검증 처리 기능 spring security와 함께 구현
> accessToken의 Payload에 회원의 고유 아이디인 userId를 claim으로 넣음
> accessToken의 유효 기간은 60분으로 설정
> accessToken 관련 에러처리는 응답통일 코드 형식으로 고칠 필요 있음
> refreshToken Redis에 저장하고 관리하는 기능 필요

## 📝작업 내용 2
> 일반 로그인 성공이후 jwt토큰(refreshToken) 발급

## 📝작업 내용 3
> ### refresh token 검증 및 access token 재발급 api 구현
> refresh token 검증 및 access token 재발급 api 과정
> 1. access token 검증
> 2. refresh token 검증
> 3. redis에 있는 refresh token과 request로 들어온 refresh token비교
> 4. refresh token들이 일치한다면 access token과 refresh token 재발급(재발급한 refresh token은 redis에 update)

## 🔎코드 설명
> 일반 로그인 성공이후 jwt토큰(accessToken) 발급 spring security와 함께 구현
> api요청 시 jwt토큰 검증 처리 기능 spring security와 함께 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> spring security의 로그인 과정을 정확히 따라갈 필요 있어보임.

## 비고 (Optional)
> x
