### PR TITLE
[Feat] 일기 내용 수정 API

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
@@ -27,6 +27,13 @@ public class DiaryConverter {
                 .build();
     }
 
+    public static DiaryResponseDTO.EditResultDTO toEditResultDTO(Diaries diaries) {
+        return DiaryResponseDTO.EditResultDTO.builder()
+                .diaryId(diaries.getId())
+                .updatedAt(diaries.getUpdatedAt())
+                .build();
+    }
+
     public static DiaryPhotos toDiaryPhoto(String pictureUrl) {
         return DiaryPhotos.builder()
                 .imageUrl(pictureUrl)

--- a/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
@@ -75,4 +75,8 @@ public class Diaries extends BaseEntity {
             diaryCategories.getDiariesList().add(this);
         }
     }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandService.java
@@ -7,4 +7,5 @@ import org.springframework.web.multipart.MultipartFile;
 public interface DiaryCommandService {
     Diaries save(DiaryRequestDTO.PostDTO postDTO, MultipartFile diaryPhotos);
     void delete(Long diaryId);
+    Diaries edit(DiaryRequestDTO.EditDTO editDTO, Long diaryId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandServiceImpl.java
@@ -76,4 +76,14 @@ public class DiaryCommandServiceImpl implements DiaryCommandService {
 
    }
 
+   @Override
+   public Diaries edit(DiaryRequestDTO.EditDTO request, Long diaryId) {
+        Diaries diaries = diaryRepository.findById((diaryId))
+                .orElseThrow(() -> new ExceptionHandler(DIARY_NOT_FOUND));
+
+        request.getContent().ifPresent(diaries::setContent);
+
+        return diaryRepository.save(diaries);
+   }
+
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -61,9 +61,14 @@ public class DiaryController {
                     """
     )
     @PatchMapping("/edit/{diaryId}")
-    public ApiResponse<Object> editDiary(@PathVariable Long diaryId,
+    public ApiResponse<DiaryResponseDTO.EditResultDTO> editDiary(@PathVariable Long diaryId,
                                          @RequestBody @Valid DiaryRequestDTO.EditDTO request) {
-        return null;
+
+        Diaries diaries = diaryCommandService.edit(request, diaryId);
+
+        return ApiResponse.onSuccess(
+                DiaryConverter.toEditResultDTO(diaries)
+        );
     }
 
     @Operation(summary = "일기 보관함",

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -34,7 +34,7 @@ public class DiaryRequestDTO {
     public static class EditDTO {
         @ExistUser
         private Long userId;
-        private String content;
+        private Optional<String> content = Optional.empty();;
     }
 
     @Getter

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -32,6 +32,7 @@ public class DiaryRequestDTO {
 
     @Getter
     public static class EditDTO {
+        @ExistUser
         private Long userId;
         private String content;
     }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
@@ -23,6 +23,15 @@ public class DiaryResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class EditResultDTO {
+        Long diaryId;
+        LocalDateTime updatedAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class KeepResultDTO {
         List<KeepDiary> diaryList;
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #43 

## 📝작업 내용
> 일기 내용 수정 API

## 🔎코드 설명
> DiaryController: editDiary -> diaryId, EditDTO / DiaryConverter.toEditResultDTO 반환
> DiaryCommandServiceImpl: diary 유효 검사 및 content 저장
> DiaryConverter: diaryId, updatedAt 반환

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x

## db, swagger
- 내용 수정 전
<img width="574" alt="스크린샷 2025-01-22 오후 5 52 01" src="https://github.com/user-attachments/assets/35342658-7eb3-4459-b8bb-6d3240d258d6" />

- swagger
<img width="441" alt="스크린샷 2025-01-22 오후 5 52 52" src="https://github.com/user-attachments/assets/842e7929-a5d1-49e1-96b7-3820a00e5fe1" />

- 내용 수정 후
<img width="515" alt="스크린샷 2025-01-22 오후 5 53 16" src="https://github.com/user-attachments/assets/c8ee66a7-f9fe-4730-9a9b-4a32388afdb4" />

