### PR TITLE
[Feat] 회원가입 중 아이디 중복 확인 API 구현

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -19,7 +19,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 회원 관련 응답 1000
     USER_ID_NULL(HttpStatus.BAD_REQUEST, "USER_1001", "사용자 아이디는 필수 입니다."),
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_1002", "해당하는 사용자가 존재하지 않습니다."),
-    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임은 필수 입니다."),
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER1003", "닉네임은 필수 입니다."),
 
     // 일기 관련 응답 2000
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_2001", "해당하는 일기가 존재하지 않습니다."),

--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -1,6 +1,7 @@
 package TtattaBackend.ttatta.converter;
 
 import TtattaBackend.ttatta.domain.Users;
+import TtattaBackend.ttatta.domain.enums.IsAvailable;
 import TtattaBackend.ttatta.domain.enums.LoginType;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserResponseDTO;
@@ -29,6 +30,12 @@ public class UserConverter {
                 .nickname(users.getNickname())
                 .loginType(users.getLoginType())
                 .createdAt(users.getCreatedAt())
+                .build();
+    }
+
+    public static UserResponseDTO.VerifyUsernameOverlapResultDTO toVerifyUsernameOverlapResultDTO(IsAvailable isAvailable) {
+        return UserResponseDTO.VerifyUsernameOverlapResultDTO.builder()
+                .isAvailable(isAvailable)
                 .build();
     }
 

--- a/src/main/java/TtattaBackend/ttatta/domain/enums/IsAvailable.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/enums/IsAvailable.java
@@ -1,0 +1,5 @@
+package TtattaBackend.ttatta.domain.enums;
+
+public enum IsAvailable {
+    AVAILABLE, UNAVAILABLE;
+}

--- a/src/main/java/TtattaBackend/ttatta/domain/enums/IsSame.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/enums/IsSame.java
@@ -1,5 +1,0 @@
-package TtattaBackend.ttatta.domain.enums;
-
-public enum IsSame {
-    TRUE, FALSE;
-}

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -1,12 +1,14 @@
 package TtattaBackend.ttatta.service.UserService;
 
 import TtattaBackend.ttatta.domain.Users;
+import TtattaBackend.ttatta.domain.enums.IsAvailable;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 
 public interface UserCommandService {
     Users createTestUser();
     Users signUp(UserRequestDTO.SignUpRequestDTO request);
     Users signIn(UserRequestDTO.SignInRequestDTO request);
+    IsAvailable verifyUsernameOverlap(String username);
     Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request);    // 미구현
     Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
     Users refresh(String request);  // 미구현

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -4,6 +4,7 @@ import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
 import TtattaBackend.ttatta.converter.UserConverter;
 import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.domain.enums.Gender;
+import TtattaBackend.ttatta.domain.enums.IsAvailable;
 import TtattaBackend.ttatta.domain.enums.LoginType;
 import TtattaBackend.ttatta.domain.enums.UserStatus;
 import TtattaBackend.ttatta.repository.UserRepository;
@@ -69,6 +70,17 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         return user;
     }
+
+    @Override
+    public IsAvailable verifyUsernameOverlap(String username) {
+        Users getUser = userRepository.findByUsername(username).orElse(null);
+        System.out.println("getUser");
+        if (getUser == null) {
+            return IsAvailable.AVAILABLE;
+        }
+        return IsAvailable.UNAVAILABLE;
+    }
+
 
     // 미구현
     @Override

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -60,15 +60,18 @@ public class UserController {
         );
     }
 
-    @Operation(summary = "아이디 중복 확인 API", description =
-            "# 아이디 중복 확인 API 입니다. 확인할 아이디를 body에 입력해주세요."
+    @Operation(summary = "회원가입 중 아이디 중복 확인 API", description =
+            "# 회원가입 중 아이디 중복 확인 API 입니다. 중복을 확인할 아이디를 body에 입력해주세요.\n"
+            + "# 아이디가 사용가능하면 AVAILABLE, 사용불가능하다면 UNAVAILABLE을 반환합니다."
     )
-    @GetMapping("/signup/same")
-    public ApiResponse<UserResponseDTO.CheckUsernameSameResultDTO> checkUsernameSame(
-            @RequestBody UserRequestDTO.CheckUsernameSameRequestDTO request
+    @GetMapping("/signup/verify/overlap")
+    public ApiResponse<UserResponseDTO.VerifyUsernameOverlapResultDTO> checkUsernameSame(
+            @RequestParam String username
     ) {
         return ApiResponse.onSuccess(
-                null
+                UserConverter.toVerifyUsernameOverlapResultDTO(
+                        userCommandService.verifyUsernameOverlap(username)
+                )
         );
     }
 

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -42,15 +42,6 @@ public class UserRequestDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class CheckUsernameSameRequestDTO {
-        private String username;
-    }  
-  
-    // 미구현
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
     public static class SignUpKakaoRequestDTO {
         private String kakaoToken;
         private String nickname;

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -1,7 +1,7 @@
 package TtattaBackend.ttatta.web.dto;
 
-import TtattaBackend.ttatta.domain.enums.IsSame;
 import TtattaBackend.ttatta.domain.enums.Gender;
+import TtattaBackend.ttatta.domain.enums.IsAvailable;
 import TtattaBackend.ttatta.domain.enums.LoginType;
 import TtattaBackend.ttatta.domain.enums.UserStatus;
 import lombok.AllArgsConstructor;
@@ -39,8 +39,8 @@ public class UserResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class CheckUsernameSameResultDTO {
-        IsSame isSame;
+    public static class VerifyUsernameOverlapResultDTO {
+        IsAvailable isAvailable;
     }
   
     // 미구현


### PR DESCRIPTION
## #️⃣연관된 이슈
> #45

## 📝작업 내용
> 회원가입 중 아이디 중복 확인 API 구현

## 🔎코드 설명
> 아이디가 사용가능하면 AVAILABLE, 사용불가능하다면 UNAVAILABLE을 반환함.
> 아이디가 중복돼 사용 불가능한 경우
> ![image](https://github.com/user-attachments/assets/d507c253-4cc2-4212-aa7e-b2eb92d026da)
> 아이디가 중복되지 않아 사용 가능한 경우
> ![image](https://github.com/user-attachments/assets/55d64e49-5e83-474d-b207-835f5bf3a2d2)

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
