### PR TITLE
[Feat] 일기 내용 수정 API 및 일기 카테고리 수정 

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
@@ -27,6 +27,13 @@ public class DiaryConverter {
                 .build();
     }
 
+    public static DiaryResponseDTO.EditResultDTO toEditResultDTO(Diaries diaries) {
+        return DiaryResponseDTO.EditResultDTO.builder()
+                .diaryId(diaries.getId())
+                .updatedAt(diaries.getUpdatedAt())
+                .build();
+    }
+
     public static DiaryPhotos toDiaryPhoto(String pictureUrl) {
         return DiaryPhotos.builder()
                 .imageUrl(pictureUrl)

--- a/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
@@ -75,4 +75,8 @@ public class Diaries extends BaseEntity {
             diaryCategories.getDiariesList().add(this);
         }
     }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
@@ -76,7 +76,7 @@ public class Diaries extends BaseEntity {
         }
     }
 
-    public void setContent(String content) {
+    public void updateContent(String content) {
         this.content = content;
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryCategoryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryCategoryRepository.java
@@ -2,6 +2,9 @@ package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.DiaryCategories;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface DiaryCategoryRepository extends JpaRepository<DiaryCategories, Long> {
+    DiaryCategories findDiaryCategoriesById(Long diaryCategoriesId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandService.java
@@ -7,4 +7,5 @@ import org.springframework.web.multipart.MultipartFile;
 public interface DiaryCommandService {
     Diaries save(DiaryRequestDTO.PostDTO postDTO, MultipartFile diaryPhotos);
     void delete(Long diaryId);
+    Diaries edit(DiaryRequestDTO.EditDTO editDTO, Long diaryId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandServiceImpl.java
@@ -81,7 +81,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService {
         Diaries diaries = diaryRepository.findById((diaryId))
                 .orElseThrow(() -> new ExceptionHandler(DIARY_NOT_FOUND));
 
-        request.getContent().ifPresent(diaries::setContent);
+        request.getContent().ifPresent(diaries::updateContent);
         request.getDiaryCategoryId().ifPresent(diaryCategoryId -> {
             DiaryCategories diaryCategories = diaryCategoryRepository.findDiaryCategoriesById(diaryCategoryId);
             diaries.setDiaryCategories(diaryCategories);

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandServiceImpl.java
@@ -14,7 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
-import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.*;
+import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.DIARY_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -82,6 +82,10 @@ public class DiaryCommandServiceImpl implements DiaryCommandService {
                 .orElseThrow(() -> new ExceptionHandler(DIARY_NOT_FOUND));
 
         request.getContent().ifPresent(diaries::setContent);
+        request.getDiaryCategoryId().ifPresent(diaryCategoryId -> {
+            DiaryCategories diaryCategories = diaryCategoryRepository.findDiaryCategoriesById(diaryCategoryId);
+            diaries.setDiaryCategories(diaryCategories);
+        });
 
         return diaryRepository.save(diaries);
    }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandServiceImpl.java
@@ -76,4 +76,14 @@ public class DiaryCommandServiceImpl implements DiaryCommandService {
 
    }
 
+   @Override
+   public Diaries edit(DiaryRequestDTO.EditDTO request, Long diaryId) {
+        Diaries diaries = diaryRepository.findById((diaryId))
+                .orElseThrow(() -> new ExceptionHandler(DIARY_NOT_FOUND));
+
+        request.getContent().ifPresent(diaries::setContent);
+
+        return diaryRepository.save(diaries);
+   }
+
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -61,9 +61,14 @@ public class DiaryController {
                     """
     )
     @PatchMapping("/edit/{diaryId}")
-    public ApiResponse<Object> editDiary(@PathVariable Long diaryId,
+    public ApiResponse<DiaryResponseDTO.EditResultDTO> editDiary(@PathVariable Long diaryId,
                                          @RequestBody @Valid DiaryRequestDTO.EditDTO request) {
-        return null;
+
+        Diaries diaries = diaryCommandService.edit(request, diaryId);
+
+        return ApiResponse.onSuccess(
+                DiaryConverter.toEditResultDTO(diaries)
+        );
     }
 
     @Operation(summary = "일기 보관함",

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -34,7 +34,7 @@ public class DiaryRequestDTO {
     public static class EditDTO {
         @ExistUser
         private Long userId;
-        private String content;
+        private Optional<String> content = Optional.empty();;
     }
 
     @Getter

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -32,6 +32,7 @@ public class DiaryRequestDTO {
 
     @Getter
     public static class EditDTO {
+        @ExistUser
         private Long userId;
         private String content;
     }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -34,7 +34,8 @@ public class DiaryRequestDTO {
     public static class EditDTO {
         @ExistUser
         private Long userId;
-        private Optional<String> content = Optional.empty();;
+        private Optional<String> content = Optional.empty();
+        private Optional<Long> diaryCategoryId = Optional.empty();
     }
 
     @Getter

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
@@ -23,6 +23,15 @@ public class DiaryResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class EditResultDTO {
+        Long diaryId;
+        LocalDateTime updatedAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class KeepResultDTO {
         List<KeepDiary> diaryList;
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #43 

## 📝작업 내용
> 내용 수정 및 카테고리 수정

## 🔎코드 설명
> DiaryController: editDiary -> diaryId, EditDTO / DiaryConverter.toEditResultDTO 반환
> DiaryCategoryRepository: 카테고리 id로 DiaryCategories 반환
> DiaryCommandServiceImpl: diary 유효 검사 및 content 저장, 카테고리 수정 및 저장
> DiaryRequestDTO: diaryCategoryId 필드 추가
> Diaries: setContent 추가

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## db
> 내용 수정 전
<img width="733" alt="스크린샷 2025-01-23 오후 4 27 03" src="https://github.com/user-attachments/assets/8c04b45e-5295-4aea-a120-696498869e4e" />

> 내용만 수정했을 때
<img width="717" alt="스크린샷 2025-01-23 오후 4 27 43" src="https://github.com/user-attachments/assets/b8cc7260-1981-4345-8e0c-ac97ef1c4cb4" />

> 카테고리만 수정했을 때
<img width="741" alt="스크린샷 2025-01-23 오후 4 28 23" src="https://github.com/user-attachments/assets/c3810d2f-f236-4020-a13b-b33bf4a948a6" />

> 둘 다 수정했을  때
<img width="759" alt="스크린샷 2025-01-23 오후 4 28 58" src="https://github.com/user-attachments/assets/f34d9d05-2f8d-47a5-b20e-aa6517415c21" />


