### PR TITLE
[Feat] 카테고리별 일기 개수 조회 및 전체 일기 개수 조회

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/DiaryCategoryConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/DiaryCategoryConverter.java
@@ -5,9 +5,8 @@ import TtattaBackend.ttatta.domain.enums.CategoryColor;
 import TtattaBackend.ttatta.web.dto.DiaryCategoryRequestDTO;
 import TtattaBackend.ttatta.web.dto.DiaryCategoryResponseDTO;
 
-import java.awt.*;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
+import java.util.List;
+
 
 public class DiaryCategoryConverter {
 
@@ -84,4 +83,13 @@ public class DiaryCategoryConverter {
                 .build();
     }
 
+
+    public static DiaryCategoryResponseDTO.GetAllCategoryCountResultDTO toGetAllCategoryCountResultDTO(
+            List<DiaryCategoryResponseDTO.GetAllCategoryCountResultDTO.CategoryDetail> categoryDetails,
+            Integer totalDiaryCount) {
+        return DiaryCategoryResponseDTO.GetAllCategoryCountResultDTO.builder()
+                .categoryDetails(categoryDetails)
+                .totalDiaryCount(totalDiaryCount)
+                .build();
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/domain/DiaryCategories.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/DiaryCategories.java
@@ -2,14 +2,10 @@ package TtattaBackend.ttatta.domain;
 
 import TtattaBackend.ttatta.domain.common.BaseEntity;
 import TtattaBackend.ttatta.domain.enums.CategoryColor;
-import TtattaBackend.ttatta.domain.enums.Gender;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
-
-import java.awt.*;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +30,7 @@ public class DiaryCategories extends BaseEntity {
     private CategoryColor color;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "users_id")
+    @JoinColumn(name = "user_id")
     private Users users;
 
     @OneToMany(mappedBy = "diaryCategories", cascade = CascadeType.ALL)

--- a/src/main/java/TtattaBackend/ttatta/domain/Users.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Users.java
@@ -26,7 +26,7 @@ public class Users extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
+    private Long id;
 
     @Column(nullable = false, length = 8)
     private String nickname;

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryCategoryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryCategoryRepository.java
@@ -2,6 +2,8 @@ package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.DiaryCategories;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface DiaryCategoryRepository extends JpaRepository<DiaryCategories, Long> {
+    List<DiaryCategories> findCategoriesByUsersId(Long userId);
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryCategoryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryCategoryRepository.java
@@ -1,9 +1,16 @@
 package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.DiaryCategories;
+import TtattaBackend.ttatta.validation.annotation.ExistDiaryCategory;
+import TtattaBackend.ttatta.validation.annotation.ExistUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryCategoryRepository extends JpaRepository<DiaryCategories, Long> {
     List<DiaryCategories> findCategoriesByUsersId(Long userId);
+    Optional<DiaryCategories> findByNameAndId(@ExistDiaryCategory @Param("name")String name, @ExistUser @Param("userId")Long userId);
+
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -2,10 +2,18 @@ package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.Diaries;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diaries, Long> {
     Integer countDiariesByDiaryCategoriesId(Long diaryCategoryId);
     Integer countDiariesByUsersId(Long userId);
+
+    @Modifying
+    @Query("UPDATE Diaries d SET d.diaryCategories.id = :targetCategoryId WHERE d.diaryCategories.id = :sourceCategoryId")
+    void updateCategoryForDiaries(@Param("sourceCategoryId") Long sourceCategoryId,
+                                  @Param("targetCategoryId") Long targetCategoryId);
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -1,10 +1,11 @@
 package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.Diaries;
-import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diaries, Long> {
+    Integer countDiariesByDiaryCategoriesId(Long diaryCategoryId);
+    Integer countDiariesByUsersId(Long userId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryCategoryService/DiaryCategoryQueryService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryCategoryService/DiaryCategoryQueryService.java
@@ -1,0 +1,11 @@
+package TtattaBackend.ttatta.service.DiaryCategoryService;
+
+import TtattaBackend.ttatta.validation.annotation.ExistUser;
+import TtattaBackend.ttatta.web.dto.DiaryCategoryResponseDTO;
+
+import java.util.List;
+
+public interface DiaryCategoryQueryService {
+    Integer getTotalDiaryCount(@ExistUser Long userId);
+    List<DiaryCategoryResponseDTO.GetAllCategoryCountResultDTO.CategoryDetail> getCategoryDetails(@ExistUser Long userId);
+}

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryCategoryService/DiaryCategoryQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryCategoryService/DiaryCategoryQueryServiceImpl.java
@@ -1,0 +1,37 @@
+package TtattaBackend.ttatta.service.DiaryCategoryService;
+
+import TtattaBackend.ttatta.repository.DiaryCategoryRepository;
+import TtattaBackend.ttatta.repository.DiaryRepository;
+import TtattaBackend.ttatta.web.dto.DiaryCategoryResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryCategoryQueryServiceImpl implements DiaryCategoryQueryService {
+
+    private final DiaryRepository diaryRepository;
+    private final DiaryCategoryRepository diaryCategoryRepository;
+
+
+    @Override
+    public Integer getTotalDiaryCount(Long userId) {
+        return diaryRepository.countDiariesByUsersId(userId);
+    }
+
+    @Override
+    public List<DiaryCategoryResponseDTO.GetAllCategoryCountResultDTO.CategoryDetail> getCategoryDetails(Long userId) {
+        return diaryCategoryRepository.findCategoriesByUsersId(userId).stream()
+                .map(category -> DiaryCategoryResponseDTO.GetAllCategoryCountResultDTO.CategoryDetail.builder()
+                        .categoryId(category.getId())
+                        .categoryName(category.getName())
+                        .categoryColor(category.getColor())
+                        .diaryCount(diaryRepository.countDiariesByDiaryCategoriesId(category.getId()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryCategoryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryCategoryController.java
@@ -1,10 +1,15 @@
 package TtattaBackend.ttatta.web.controller;
 
 import TtattaBackend.ttatta.apiPayload.ApiResponse;
+import TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus;
+import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
 import TtattaBackend.ttatta.converter.DiaryCategoryConverter;
 import TtattaBackend.ttatta.domain.DiaryCategories;
+import TtattaBackend.ttatta.repository.UserRepository;
 import TtattaBackend.ttatta.service.DiaryCategoryService.DiaryCategoryCommandService;
+import TtattaBackend.ttatta.service.DiaryCategoryService.DiaryCategoryQueryService;
 import TtattaBackend.ttatta.validation.annotation.ExistDiaryCategory;
+import TtattaBackend.ttatta.validation.annotation.ExistUser;
 import TtattaBackend.ttatta.web.dto.DiaryCategoryRequestDTO;
 import TtattaBackend.ttatta.web.dto.DiaryCategoryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,12 +18,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @Validated
 @RequestMapping("/categories")
 public class DiaryCategoryController {
     private final DiaryCategoryCommandService diaryCategoryCommandService;
+    private final DiaryCategoryQueryService diaryCategoryQueryService;
+    private final UserRepository userRepository;
 
     @Operation(summary = "카테고리 생성 api", description =
             "새로운 카테고리를 생성할 때 사용하는 api 입니다.\n카테고리 이름과 색상, 사용자의 id 데이터를 넣어주시면 됩니다."
@@ -76,7 +85,16 @@ public class DiaryCategoryController {
             "모든 카테고리의 각각의 일기 개수와 전체 일기 개수를 알려주는 api입니다.\n사용자의 Id데이터를 넣어주시면 됩니다."
     )
     @GetMapping("/diary-counts")
-    public ApiResponse<DiaryCategoryResponseDTO.GetAllCategoryCountResultDTO> count(@RequestBody @Valid DiaryCategoryRequestDTO.GetAllCategoryCountDTO request) {
-        return null;
+    public ApiResponse<DiaryCategoryResponseDTO.GetAllCategoryCountResultDTO> getDiaryCount(@RequestParam Long userId) {
+
+        if (userRepository.findById(userId).isEmpty()) {
+            throw new ExceptionHandler(ErrorStatus.USER_NOT_FOUND);
+        }
+
+        List<DiaryCategoryResponseDTO.GetAllCategoryCountResultDTO.CategoryDetail> details = diaryCategoryQueryService.getCategoryDetails(userId);
+        Integer totalCount = diaryCategoryQueryService.getTotalDiaryCount(userId);
+
+        DiaryCategoryResponseDTO.GetAllCategoryCountResultDTO result = DiaryCategoryConverter.toGetAllCategoryCountResultDTO(details, totalCount);
+        return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryCategoryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryCategoryRequestDTO.java
@@ -29,17 +29,17 @@ public class DiaryCategoryRequestDTO {
 
     @Getter
     public static class DeleteCategoryDTO {
+        @ExistUser
         Long userId;
     }
 
     @Getter
     public static class DeleteAllCategoryDTO {
+        @ExistUser
         Long userId;
     }
 
     @Getter
     public static class GetAllCategoryCountDTO {
-        Long userId;
     }
-
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryCategoryResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryCategoryResponseDTO.java
@@ -54,7 +54,7 @@ public class DiaryCategoryResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GetAllCategoryCountResultDTO {
-        List<CategoryDetail> categories;
+        List<CategoryDetail> categoryDetails;
         Integer totalDiaryCount;
         @Builder
         @Getter
@@ -64,6 +64,7 @@ public class DiaryCategoryResponseDTO {
             Long categoryId;
             String categoryName;
             Integer diaryCount;
+            CategoryColor categoryColor;
         }
     }
 
@@ -75,11 +76,11 @@ public class DiaryCategoryResponseDTO {
         Long categoryId;
     }
 
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class DiaryCategoryColorExceptionDTO{
-        String categoryColor;
-    }
+//    @Builder
+//    @Getter
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    public static class DiaryCategoryColorExceptionDTO{
+//        String categoryColor;
+//    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryCategoryResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryCategoryResponseDTO.java
@@ -75,12 +75,4 @@ public class DiaryCategoryResponseDTO {
     public static class DiaryCategoryExceptionDTO{
         Long categoryId;
     }
-
-//    @Builder
-//    @Getter
-//    @NoArgsConstructor
-//    @AllArgsConstructor
-//    public static class DiaryCategoryColorExceptionDTO{
-//        String categoryColor;
-//    }
 }


### PR DESCRIPTION
카테고리별 일기 개수 조회 및 전체 일기 개수 조회 API

## #️⃣연관된 이슈
> #48 

## 📝작업 내용
> API 구현
> 스웨거 테스트 완료

## 🔎코드 설명
> 카테고리별 일기 개수 및 정보를 리스트로 보여주고, 전체 일기 개수를 보여준다.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 에러 핸들러 -> controller에 @ExistUser 어노테이션 사용 시 에러 발생...

## 비고 (Optional)
> 
<img width="832" alt="스크린샷 2025-01-23 오후 6 57 33" src="https://github.com/user-attachments/assets/a43e335a-5647-40de-9a7f-7530a2f81a82" />

