### PR TITLE
[Fix] errorstatus enum에 ';'대신 ','가 들어가야 하는 것 수정

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -29,7 +29,7 @@ public enum ErrorStatus implements BaseErrorCode {
     DIARY_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_CATEGORY_3001", "해당하는 일기 카테고리가 존재하지 않습니다."),
     DIARY_CATEGORY_IS_NULL(HttpStatus.BAD_REQUEST, "DIARY_CATEGORY_3002", "일기 카테고리는 필수 입니다."),
     DIARY_CATEGORY_COLOR_NOT_FOUND(HttpStatus.NOT_FOUND,"DIARY_CATEGORY_3003","해당하는 일기 카테고리 색상은 존재하지 않습니다."),
-    DIARY_CATEGORY_COLOR_NULL(HttpStatus.BAD_REQUEST, "DIARY_CATEGORY_3004", "일기 카테고리 색상은 필수 입니다.");
+    DIARY_CATEGORY_COLOR_NULL(HttpStatus.BAD_REQUEST, "DIARY_CATEGORY_3004", "일기 카테고리 색상은 필수 입니다."),
 
     // jwt 토큰 관련 응답 4000
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "TOKEN_4001", "토큰이 전달되지 않았습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈
> #56 

## 📝작업 내용
> errorstatus enum에 ';'대신 ','가 들어가야 하는 것 수정

## 🔎코드 설명
> errorstatus enum에 ';'대신 ','가 들어가야 하는 것 수정

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
