### PR TITLE
[Feat] 회원가입 시 회원마다 일상 카테고리 추가 기능 구현 완료

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -6,12 +6,15 @@ import TtattaBackend.ttatta.domain.enums.LoginType;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserResponseDTO;
 
+import java.util.ArrayList;
+
 public class UserConverter {
     public static Users toUsers(UserRequestDTO.SignUpRequestDTO request) {
         return Users.builder()
                 .nickname(request.getNickname())
                 .username(request.getUsername())
                 .loginType(LoginType.REGULAR)
+                .diaryCategoriesList(new ArrayList<>())
                 .build();
     }
 

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -2,14 +2,16 @@ package TtattaBackend.ttatta.service.UserService;
 
 import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
 import TtattaBackend.ttatta.config.security.SecurityUtil;
+import TtattaBackend.ttatta.converter.DiaryCategoryConverter;
 import TtattaBackend.ttatta.converter.UserConverter;
+import TtattaBackend.ttatta.domain.DiaryCategories;
 import TtattaBackend.ttatta.domain.Users;
-import TtattaBackend.ttatta.domain.enums.Gender;
-import TtattaBackend.ttatta.domain.enums.IsAvailable;
-import TtattaBackend.ttatta.domain.enums.LoginType;
-import TtattaBackend.ttatta.domain.enums.UserStatus;
+import TtattaBackend.ttatta.domain.enums.*;
 import TtattaBackend.ttatta.jwt.JwtUtils;
+import TtattaBackend.ttatta.repository.DiaryCategoryRepository;
 import TtattaBackend.ttatta.repository.UserRepository;
+import TtattaBackend.ttatta.web.dto.DiaryCategoryRequestDTO;
+import TtattaBackend.ttatta.web.dto.DiaryCategoryResponseDTO;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserResponseDTO;
 import jakarta.transaction.Transactional;
@@ -41,6 +43,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Value("${jwt.REFRESH_EXP_TIME}")
     private int refreshExpTime;
     private final UserRepository userRepository;
+    private final DiaryCategoryRepository diaryCategoryRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtUtils jwtUtils;
@@ -70,7 +73,20 @@ public class UserCommandServiceImpl implements UserCommandService {
     public Users signUp(UserRequestDTO.SignUpRequestDTO request) {
         Users newUser = UserConverter.toUsers(request);
         newUser.encodePassword(passwordEncoder.encode(request.getPassword()));
+        // 일상 카테고리 생성
+        createDefaultCategory(newUser);
         return userRepository.save(newUser);
+    }
+
+    private void createDefaultCategory(Users newUser) {
+        DiaryCategories defaultDiaryCategories = DiaryCategoryConverter.toDiaryCategory(
+                DiaryCategoryRequestDTO.CreateCategoryDTO.builder()
+                    .categoryName("일상")
+                    .categoryColor(CategoryColor.RED)
+                    .build()
+        );
+        defaultDiaryCategories.setUsers(newUser);
+        diaryCategoryRepository.save(defaultDiaryCategories);
     }
 
     @Override

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryCategoryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryCategoryRequestDTO.java
@@ -4,6 +4,7 @@ import TtattaBackend.ttatta.domain.enums.CategoryColor;
 import TtattaBackend.ttatta.validation.annotation.ExistDiaryCategory;
 import TtattaBackend.ttatta.validation.annotation.ExistDiaryCategoryColor;
 import TtattaBackend.ttatta.validation.annotation.ExistUser;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.Optional;
@@ -11,6 +12,7 @@ import java.util.Optional;
 public class DiaryCategoryRequestDTO {
 
     @Getter
+    @Builder
     public static class CreateCategoryDTO {
         String categoryName;
         CategoryColor categoryColor;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #67 

## 📝작업 내용
> 회원가입 시 회원마다 일상 카테고리 추가 기능 구현 완료

## 🔎코드 설명
> 회원가입 시 회원마다 일상 카테고리 추가 기능 구현 완료
> UserCommandServiceImpl에 일상 카테고리를 추가하는 createDefaultCategory메서드 구현
> 카카오 회원가입시에도 적용하기 위해 createDefaultCategory메서드를 구현함.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x
## 비고 (Optional)
> x
