### PR TITLE
[Feat] 일기 보관함 일기 조회 및 캘린더 클릭 시 해당 날짜 일기 조회

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
@@ -4,8 +4,11 @@ import TtattaBackend.ttatta.domain.Diaries;
 import TtattaBackend.ttatta.domain.DiaryPhotos;
 import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
 import TtattaBackend.ttatta.web.dto.DiaryResponseDTO;
+import org.springframework.data.domain.Page;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class DiaryConverter {
 
@@ -40,8 +43,26 @@ public class DiaryConverter {
                 .build();
     }
 
-    public static DiaryResponseDTO.KeepResultDTO toKeepResultDTO(Diaries diaries) {
-        return null;
+    public static DiaryResponseDTO.KeepDiaryDTO toKeepDiaryDTO(Diaries diaries) {
+        List<String> imageUrl = diaries.getDiaryPhotosList().stream()
+                .map(DiaryPhotos::getImageUrl).collect(Collectors.toList());
+
+        return DiaryResponseDTO.KeepDiaryDTO.builder()
+                .diaryId(diaries.getId())
+                .date(diaries.getDate())
+                .content(diaries.getContent())
+                .image(imageUrl.toString())
+                .locationName(diaries.getLocationName())
+                .build();
+    }
+
+    public static DiaryResponseDTO.KeepDiaryListDTO toKeepDiaryListDTO(Page<Diaries> diaryList) {
+        List<DiaryResponseDTO.KeepDiaryDTO> keepDiaryDTOList = diaryList.stream()
+                .map(DiaryConverter::toKeepDiaryDTO).collect(Collectors.toList());
+
+        return DiaryResponseDTO.KeepDiaryListDTO.builder()
+                .diaryList(keepDiaryDTOList)
+                .build();
     }
 
     public static DiaryResponseDTO.MapResultDTO toMapResultDTO(Diaries diaries) {

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -2,12 +2,15 @@ package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.Diaries;
 import TtattaBackend.ttatta.domain.DiaryCategories;
+import TtattaBackend.ttatta.domain.Users;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -15,4 +18,9 @@ public interface DiaryRepository extends JpaRepository<Diaries, Long> {
     Integer countDiariesByDiaryCategoriesId(Long diaryCategoryId);
     Integer countDiariesByUsersId(Long userId);
     List<Diaries> findAllByDiaryCategories(DiaryCategories diaryCategories);
+
+    Page<Diaries> findAllByUsersOrderByDateDesc(Users user, PageRequest pageRequest);
+
+    @Query("SELECT d FROM Diaries d WHERE d.users = :user AND FUNCTION('DATE', d.date) = FUNCTION('DATE', :date) ORDER BY d.date DESC")
+    Page<Diaries> findAllByUsersAndDateOrderByDateDesc(@Param("user") Users user, @Param("date") LocalDateTime date, PageRequest pageRequest);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryService.java
@@ -1,0 +1,11 @@
+package TtattaBackend.ttatta.service.DiaryService;
+
+import TtattaBackend.ttatta.domain.Diaries;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+
+
+public interface DiaryQueryService {
+    Page<Diaries> getDiaryList(LocalDateTime date, int requestNum);
+}

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
@@ -1,0 +1,42 @@
+package TtattaBackend.ttatta.service.DiaryService;
+
+
+import TtattaBackend.ttatta.config.security.SecurityUtil;
+import TtattaBackend.ttatta.domain.Diaries;
+import TtattaBackend.ttatta.domain.Users;
+import TtattaBackend.ttatta.repository.DiaryRepository;
+import TtattaBackend.ttatta.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiaryQueryServiceImpl implements DiaryQueryService{
+
+    private final DiaryRepository diaryRepository;
+
+    private final UserRepository userRepository;
+
+    @Override
+    public Page<Diaries> getDiaryList(LocalDateTime date, int requestNum) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        Users user =  userRepository.findById(userId).get();
+
+        Page<Diaries> diariesPage;
+
+        if(date == null) {
+            diariesPage = diaryRepository.findAllByUsersOrderByDateDesc(user, PageRequest.of(requestNum, 5));
+        } else {
+            diariesPage = diaryRepository.findAllByUsersAndDateOrderByDateDesc(user, date, PageRequest.of(requestNum, 5));
+        }
+
+        return diariesPage;
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -61,8 +61,8 @@ public class DiaryController {
 
     @Operation(summary = "일기 수정",
             description = """
-                    일기 id, 수정할 일기의 내용을 작성해주세요.
-                    현재는 내용만 수정 가능합니다.
+                    일기 id, 수정할 일기의 내용(필수), 수정할 카테고리 id(선택)를 작성해주세요.\n
+                    카테고리 수정 없을 시 null로 보내주세요.
                     """
     )
     @PatchMapping("/edit/{diaryId}")

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -4,6 +4,7 @@ import TtattaBackend.ttatta.apiPayload.ApiResponse;
 import TtattaBackend.ttatta.converter.DiaryConverter;
 import TtattaBackend.ttatta.domain.Diaries;
 import TtattaBackend.ttatta.service.DiaryService.DiaryCommandService;
+import TtattaBackend.ttatta.service.DiaryService.DiaryQueryService;
 import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
 import TtattaBackend.ttatta.web.dto.DiaryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,9 +12,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/diaries")
@@ -21,6 +25,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class DiaryController {
 
     private final DiaryCommandService diaryCommandService;
+
+    private final DiaryQueryService diaryQueryService;
 
     @Operation(summary = "일기 작성",
             description = """
@@ -30,7 +36,7 @@ public class DiaryController {
     )
 
     @PostMapping(value = "/post", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ApiResponse<DiaryResponseDTO.PostResultDTO> diarySave(   @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    public ApiResponse<DiaryResponseDTO.PostResultDTO> diarySave(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                                                  @RequestPart @Valid DiaryRequestDTO.PostDTO request,
                                                                  @RequestPart("image") MultipartFile diaryPhotos){
         Diaries diaries = diaryCommandService.save(request, diaryPhotos);
@@ -70,16 +76,21 @@ public class DiaryController {
         );
     }
 
-    @Operation(summary = "일기 보관함",
+    @Operation(summary = "일기 보관함 화면에서 전체 일기 반환, 캘린더 클릭 시 날짜에 해당하는 일기 반환",
         description = """
-                날짜(선택), 페이징 번호(필수)를 작성해주세요.
-                일기 보관함 화면에서 조회할 수 있는 일기가 최신순으로 반환됩니다.
+                페이징 번호(필수) -> Path variable, 날짜(선택) -> Query String를 작성해주세요.\n
+                날짜 없으면 전체, 있으면 해당 날짜의 일기 반환\n
+                일기는 최신순으로 반환됩니다.
                 """
     )
     @GetMapping("/keep/{requestNum}")
-    public ApiResponse<DiaryResponseDTO.KeepResultDTO> getKeepDiary(@PathVariable int requestNum,
-                                                                    @RequestBody @Valid DiaryRequestDTO.KeepDTO request) {
-        return null;
+    public ApiResponse<DiaryResponseDTO.KeepDiaryListDTO> getKeepDiaryList(@PathVariable int requestNum,
+                                                                           @RequestParam(required = false) LocalDateTime date) {
+        Page<Diaries> diaryList = diaryQueryService.getDiaryList(date,requestNum);
+
+        return ApiResponse.onSuccess(
+                DiaryConverter.toKeepDiaryListDTO(diaryList)
+        );
     }
 
     @Operation(summary = "일기 지도",

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -27,10 +27,6 @@ public class DiaryRequestDTO {
         private Optional<Long> diaryCategoryId = Optional.empty();
     }
 
-    @Getter
-    public static class KeepDTO {
-        private Optional<LocalDateTime> date = Optional.empty();
-    }
 
     @Getter
     public static class MapDTO {

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
@@ -32,19 +32,20 @@ public class DiaryResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class KeepResultDTO {
-        List<KeepDiary> diaryList;
+    public static class KeepDiaryListDTO {
+        List<KeepDiaryDTO> diaryList;
+    }
 
-        @Getter
-        @Builder
-        @NoArgsConstructor
-        @AllArgsConstructor
-        public static class KeepDiary {
-            Long diaryId;
-            LocalDateTime date;
-            String content;
-            String image;
-        }
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KeepDiaryDTO {
+        Long diaryId;
+        LocalDateTime date;
+        String content;
+        String image;
+        String locationName;
     }
 
     @Getter


### PR DESCRIPTION
## #️⃣연관된 이슈
> #69 

## 📝작업 내용
> 일기 보관함에서 사용자의 전체 일기를 최신순으로 조회
> 캘린더에서 날짜 클릭 시 해당 날짜의 일기를 최신순으로 조회

## 🔎코드 설명
> Controller: 매개변수로 페이징 번호와, 날짜(선택) 받음
> ServiceImpl: date가 있을 경우, 없을 경우로 나누어 없을 경우는 전체 일기 최신순 조회, 있을 경우 해당 날짜 일기만 최신순 조회
> 현재 한 페이징 당 일기 5개씩 반환(수정 가능)

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 일기 보관함과 캘린더 화면의 API를 하나로 합쳐서 사용
> 필요 시 분리

## 비고 (Optional)
> x

