### PR TITLE
[Feat] 검색 시 해당 일기 조회 API

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
@@ -77,14 +77,14 @@ public class DiaryConverter {
     }
 
     public static DiaryResponseDTO.SearchDiaryDTO toSearchDiaryDTO(Diaries diaries) {
-        List<String> imageUrl = diaries.getDiaryPhotosList().stream()
-                .map(DiaryPhotos::getImageUrl).collect(Collectors.toList());
+        String imageUrl = diaries.getDiaryPhotosList().stream()
+                .map(DiaryPhotos::getImageUrl).collect(Collectors.toList()).get(0);
 
         return DiaryResponseDTO.SearchDiaryDTO.builder()
                 .diaryId(diaries.getId())
                 .content(diaries.getContent())
                 .date(diaries.getDate())
-                .image(imageUrl.toString())
+                .image(imageUrl)
                 .locationName(diaries.getLocationName())
                 .build();
     }
@@ -92,6 +92,7 @@ public class DiaryConverter {
     public static DiaryResponseDTO.SearchDiaryListDTO toSearchDiaryListDTO(Page<Diaries> diaryList) {
         List<DiaryResponseDTO.SearchDiaryDTO> searchDiaryList = diaryList.stream()
                 .map(DiaryConverter::toSearchDiaryDTO).collect(Collectors.toList());
+
 
         return DiaryResponseDTO.SearchDiaryListDTO.builder()
                 .searchDiaryList(searchDiaryList)

--- a/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
@@ -76,7 +76,25 @@ public class DiaryConverter {
 
     }
 
-    public static DiaryResponseDTO.SearchResultDTO toSearchResultDTO(Diaries diaries) {
-        return null;
+    public static DiaryResponseDTO.SearchDiaryDTO toSearchDiaryDTO(Diaries diaries) {
+        List<String> imageUrl = diaries.getDiaryPhotosList().stream()
+                .map(DiaryPhotos::getImageUrl).collect(Collectors.toList());
+
+        return DiaryResponseDTO.SearchDiaryDTO.builder()
+                .diaryId(diaries.getId())
+                .content(diaries.getContent())
+                .date(diaries.getDate())
+                .image(imageUrl.toString())
+                .locationName(diaries.getLocationName())
+                .build();
+    }
+
+    public static DiaryResponseDTO.SearchDiaryListDTO toSearchDiaryListDTO(Page<Diaries> diaryList) {
+        List<DiaryResponseDTO.SearchDiaryDTO> searchDiaryList = diaryList.stream()
+                .map(DiaryConverter::toSearchDiaryDTO).collect(Collectors.toList());
+
+        return DiaryResponseDTO.SearchDiaryListDTO.builder()
+                .searchDiaryList(searchDiaryList)
+                .build();
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -23,4 +23,7 @@ public interface DiaryRepository extends JpaRepository<Diaries, Long> {
 
     @Query("SELECT d FROM Diaries d WHERE d.users = :user AND FUNCTION('DATE', d.date) = FUNCTION('DATE', :date) ORDER BY d.date DESC")
     Page<Diaries> findAllByUsersAndDateOrderByDateDesc(@Param("user") Users user, @Param("date") LocalDateTime date, PageRequest pageRequest);
+
+    @Query("SELECT d FROM Diaries d WHERE d.users = :user AND d.content LIKE %:content% ORDER BY d.date DESC")
+    Page<Diaries> findAllByUsersAndContent(@Param("user")Users user, @Param("content") String content, PageRequest pageRequest);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryService.java
@@ -8,4 +8,5 @@ import java.time.LocalDateTime;
 
 public interface DiaryQueryService {
     Page<Diaries> getDiaryList(LocalDateTime date, int requestNum);
+    Page<Diaries> getSearchDiaryList(String content, int requestNum);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
@@ -39,4 +39,15 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
 
         return diariesPage;
     }
+
+    @Override
+    public Page<Diaries> getSearchDiaryList(String content, int requestNum) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        Users user = userRepository.findById(userId).get();
+
+        Page<Diaries> diariesPage = diaryRepository.findAllByUsersAndContent(user, content, PageRequest.of(requestNum, 5));
+
+        return diariesPage;
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -107,15 +107,15 @@ public class DiaryController {
 
     @Operation(summary = "일기 검색",
         description = """
-                검색 내용(필수), 페이징 번호를 작성해주세요.
-                검색한 내용이 들어가 있는 일기가 반환됩니다.
+                검색 내용(필수), 페이징 번호(필수)를 작성해주세요.\n
+                검색한 내용이 들어가 있는 일기가 최신순으로 5개씩 반환됩니다.
                 """
     )
     @GetMapping("/search/{requestNum}")
     public ApiResponse<DiaryResponseDTO.SearchDiaryListDTO> getSearchDiary(@PathVariable int requestNum,
-                                                                           @RequestParam String content) {
+                                                                           @RequestParam String searchContent) {
 
-        Page<Diaries> searchDiaryList = diaryQueryService.getSearchDiaryList(content, requestNum);
+        Page<Diaries> searchDiaryList = diaryQueryService.getSearchDiaryList(searchContent, requestNum);
 
         return ApiResponse.onSuccess(
                 DiaryConverter.toSearchDiaryListDTO(searchDiaryList)

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -107,14 +107,19 @@ public class DiaryController {
 
     @Operation(summary = "일기 검색",
         description = """
-                검색 내용, 페이징 번호를 작성해주세요.
+                검색 내용(필수), 페이징 번호를 작성해주세요.
                 검색한 내용이 들어가 있는 일기가 반환됩니다.
                 """
     )
     @GetMapping("/search/{requestNum}")
-    public ApiResponse<DiaryResponseDTO.SearchResultDTO> getSearchDiary(@PathVariable int requestNum,
-                                                                        @RequestBody @Valid DiaryRequestDTO.SearchDTO request) {
-        return null;
+    public ApiResponse<DiaryResponseDTO.SearchDiaryListDTO> getSearchDiary(@PathVariable int requestNum,
+                                                                           @RequestParam String content) {
+
+        Page<Diaries> searchDiaryList = diaryQueryService.getSearchDiaryList(content, requestNum);
+
+        return ApiResponse.onSuccess(
+                DiaryConverter.toSearchDiaryListDTO(searchDiaryList)
+        );
     }
 
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -33,9 +33,4 @@ public class DiaryRequestDTO {
         private double latitude;
         private double longitude;
     }
-
-    @Getter
-    public static class SearchDTO {
-        private String searchContent;
-    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
@@ -64,18 +64,19 @@ public class DiaryResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class SearchResultDTO {
-        List<SearchDiary> diaryList;
+    public static class SearchDiaryListDTO {
+        List<SearchDiaryDTO> searchDiaryList;
+    }
 
-        @Getter
-        @Builder
-        @NoArgsConstructor
-        @AllArgsConstructor
-        public static class SearchDiary {
-            Long diaryId;
-            LocalDateTime date;
-            String content;
-            String image;
-        }
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SearchDiaryDTO {
+        Long diaryId;
+        LocalDateTime date;
+        String content;
+        String image;
+        String locationName;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #73 

## 📝작업 내용
> 요청된 문자열이 포함된 일기를 조회, 최신순으로 반환

## 🔎코드 설명
> Controller: Path Variable로 requestNum, Query String으로 searchContent 받아옴
> ServiceImpl: user와 content로 일기 조회하는 로직 구현
> repository: 해당 유저가 쓴 일기 중, searchContent를 포함하고 있는 일기 최신순 반환
> Converter: List로 반환되게 변환

## 💬고민사항 및 리뷰 요구사항 (Optional)
> response를 보면 이미지 부분이 리스트 형식으로 되어있는데
> [ ] (대괄호로 한번 더 감싸져 있음)
> 이미지를 여러개 할 걸 대비해서 List<String>으로 처리하고 있기 때문에 저렇게 결과가 나온다고 생각
> 이거 그대로 둘 지 아니면 String으로 처리해서 대괄호 없애는 모양으로 반환할 지

## 비고 (Optional)
> x

## swagger (사용자 일기 총 6개라고 가정)
- requestNum: 0, searchContent: 일기
<img width="221" alt="스크린샷 2025-01-29 오전 1 09 30" src="https://github.com/user-attachments/assets/48a2c141-d3b5-4462-a55a-6e078cd8006b" />
<img width="214" alt="스크린샷 2025-01-29 오전 1 09 40" src="https://github.com/user-attachments/assets/5b8b5ed5-d554-4452-9b7a-25597087be2d" />


- requestNum:1, searchContent: 일기
<img width="216" alt="스크린샷 2025-01-29 오전 1 09 56" src="https://github.com/user-attachments/assets/1aef69d4-7432-4c7f-820e-516e882a191d" />

- requestNum: 0, searchContent: 5
<img width="206" alt="스크린샷 2025-01-29 오전 1 11 07" src="https://github.com/user-attachments/assets/29b7361e-30f1-4b0a-b93d-30d857cdc1ed" />


 ## image 리스트 수정 완료
<img width="179" alt="스크린샷 2025-02-01 오후 4 25 14" src="https://github.com/user-attachments/assets/abdf48c2-1794-4b17-94e6-f1a950b51529" />
