### PR TITLE
[Feat] 일기 사진 교체 기능 구현

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandService.java
@@ -1,11 +1,15 @@
 package TtattaBackend.ttatta.service.DiaryService;
 
 import TtattaBackend.ttatta.domain.Diaries;
+import TtattaBackend.ttatta.domain.DiaryPhotos;
 import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface DiaryCommandService {
     Diaries save(DiaryRequestDTO.PostDTO postDTO, MultipartFile diaryPhotos);
+    DiaryPhotos savePhoto(MultipartFile diaryPhoto);
     void delete(Long diaryId);
-    Diaries edit(DiaryRequestDTO.EditDTO editDTO, Long diaryId);
+    void deletePhoto(DiaryPhotos diaryPhoto);
+    Diaries edit(DiaryRequestDTO.EditDTO editDTO, Long diaryId, MultipartFile editPhoto);
+
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandServiceImpl.java
@@ -103,9 +103,6 @@ public class DiaryCommandServiceImpl implements DiaryCommandService {
                 .orElseThrow(() -> new ExceptionHandler(DIARY_NOT_FOUND));
         DiaryPhotos diaryPhoto = diaryPhotosRepository.findByDiaries_Id(diaries.getId());
 
-        System.out.println("diaryCategoryId: " + request.getDiaryCategoryId());
-        System.out.println("content: " + request.getContent());
-
         // 카테고리 수정
         request.getContent().ifPresent(diaries::updateContent);
         request.getDiaryCategoryId().ifPresent(diaryCategoryId -> {
@@ -113,7 +110,6 @@ public class DiaryCommandServiceImpl implements DiaryCommandService {
             diaries.setDiaryCategories(diaryCategories);
         });
 
-       System.out.println(editPhoto);
         // 사진 수정
         if(editPhoto != null) {
             deletePhoto(diaryPhoto);

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryCommandServiceImpl.java
@@ -48,16 +48,24 @@ public class DiaryCommandServiceImpl implements DiaryCommandService {
         Diaries savedDiaries = diaryRepository.save(diaries);
 
         // 일기 사진
-        String uuid = UUID.randomUUID().toString();
-        Uuid savedUuid = uuidRepository.save(Uuid.builder()
-                .uuid(uuid).build());
-        String pictureUrl = s3Manager.uploadFile(s3Manager.generateDiaryKeyName(savedUuid), diaryPhoto);
-        DiaryPhotos diaryPhotos = DiaryConverter.toDiaryPhoto(pictureUrl);
+        DiaryPhotos diaryPhotos = savePhoto(diaryPhoto);
 
         diaryPhotos.setDiaries(savedDiaries);
         diaryPhotosRepository.save(diaryPhotos);
 
         return savedDiaries;
+   }
+
+   // s3 객체 사진 저장
+   @Override
+   public DiaryPhotos savePhoto(MultipartFile diaryPhoto) {
+       String uuid = UUID.randomUUID().toString();
+       Uuid savedUuid = uuidRepository.save(Uuid.builder()
+               .uuid(uuid).build());
+       String pictureUrl = s3Manager.uploadFile(s3Manager.generateDiaryKeyName(savedUuid), diaryPhoto);
+       DiaryPhotos diaryPhotos = DiaryConverter.toDiaryPhoto(pictureUrl);
+
+       return diaryPhotos;
    }
 
    @Override
@@ -68,27 +76,50 @@ public class DiaryCommandServiceImpl implements DiaryCommandService {
 
         DiaryPhotos diaryPhoto = diaryPhotosRepository.findByDiaries_Id(diaries.getId());
 
-        String savedUuid = s3Manager.getUuidByUrl(diaryPhoto.getImageUrl());
-
-        Uuid uuid = uuidRepository.findByUuid(savedUuid);
-        uuidRepository.delete(uuid);
-
-        s3Manager.deleteFile(s3Manager.generateDiaryKeyName(uuid));
+        deletePhoto(diaryPhoto);
 
         diaryRepository.delete(diaries);
 
    }
 
+   // s3에서 객체 삭제
    @Override
-   public Diaries edit(DiaryRequestDTO.EditDTO request, Long diaryId) {
+   public void deletePhoto(DiaryPhotos diaryPhoto) {
+       String savedUuid = s3Manager.getUuidByUrl(diaryPhoto.getImageUrl());
+
+       Uuid uuid = uuidRepository.findByUuid(savedUuid);
+       uuidRepository.delete(uuid);
+
+       s3Manager.deleteFile(s3Manager.generateDiaryKeyName(uuid));
+
+       // db에서 삭제
+       diaryPhotosRepository.delete(diaryPhoto);
+   }
+
+
+   @Override
+   public Diaries edit(DiaryRequestDTO.EditDTO request, Long diaryId, MultipartFile editPhoto) {
         Diaries diaries = diaryRepository.findById((diaryId))
                 .orElseThrow(() -> new ExceptionHandler(DIARY_NOT_FOUND));
+        DiaryPhotos diaryPhoto = diaryPhotosRepository.findByDiaries_Id(diaries.getId());
 
+        System.out.println("diaryCategoryId: " + request.getDiaryCategoryId());
+        System.out.println("content: " + request.getContent());
+
+        // 카테고리 수정
         request.getContent().ifPresent(diaries::updateContent);
         request.getDiaryCategoryId().ifPresent(diaryCategoryId -> {
             DiaryCategories diaryCategories = diaryCategoryRepository.findDiaryCategoriesById(diaryCategoryId);
             diaries.setDiaryCategories(diaryCategories);
         });
+
+       System.out.println(editPhoto);
+        // 사진 수정
+        if(editPhoto != null) {
+            deletePhoto(diaryPhoto);
+            DiaryPhotos diaryPhotos = savePhoto(editPhoto);
+            diaryPhotos.setDiaries(diaries);
+        }
 
         return diaryRepository.save(diaries);
    }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -61,15 +61,19 @@ public class DiaryController {
 
     @Operation(summary = "일기 수정",
             description = """
-                    일기 id, 수정할 일기의 내용(필수), 수정할 카테고리 id(선택)를 작성해주세요.\n
-                    카테고리 수정 없을 시 null로 보내주세요.
+                    일기 id -> Path Variable \n
+                    수정할 일기의 내용, 수정할 카테고리 id, 수정할 사진 파일 -> body 를 작성해주세요.\n
+                    ⭐️ 수정 하는 항목만 보내주세요. ⭐️\n
+                    ⭐️ body에 들어오는 -> 내용/카테고리 id/파일 중 최소 하나는 필수로 들어와야 합니다. ⭐️
                     """
     )
-    @PatchMapping("/edit/{diaryId}")
+    @PatchMapping(value = "/edit/{diaryId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ApiResponse<DiaryResponseDTO.EditResultDTO> editDiary(@PathVariable Long diaryId,
-                                         @RequestBody @Valid DiaryRequestDTO.EditDTO request) {
+                                                                 @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+                                                                 @RequestPart @Valid DiaryRequestDTO.EditDTO request,
+                                                                 @RequestPart(required = false) MultipartFile editPhoto) {
 
-        Diaries diaries = diaryCommandService.edit(request, diaryId);
+        Diaries diaries = diaryCommandService.edit(request, diaryId, editPhoto);
 
         return ApiResponse.onSuccess(
                 DiaryConverter.toEditResultDTO(diaries)


### PR DESCRIPTION
일기 사진 교체 기능 추가
일기 사진 저장, 일기 사진 삭제하는 메서드를 분리
교체할 사진이 들어오면 s3 객체 삭제 -> db 삭제 -> s3 객체 생성 -> db 저장

## #️⃣연관된 이슈
> #77 

## 📝작업 내용
> 일기 수정 시 사진 교체 기능 추가

## 🔎코드 설명
> Controller: application/json 에서 multipart/form-data 형식으로 변환, editPhoto 추가
> Impl: s3에 저장하는 savePhoto, s3에서 삭제하는 deletePhoto 메서드 분리, edit 메서드에 editPhoto 있을 경우 객체 삭제 후 저장하는 로직 추가

## 💬고민사항 및 리뷰 요구사항 (Optional)
> s3에 바로 수정하는 방법이 없는 것 같아서 객체 삭제 후 다시 저장하는 로직으로 구현.. 

## 비고 (Optional)
> x

## API 명세서
<img width="859" alt="스크린샷 2025-01-31 오후 3 56 20" src="https://github.com/user-attachments/assets/aa70feff-a2c1-407e-9814-2ad70156ab68" />

## DB
- 사진 수정 전
<img width="355" alt="스크린샷 2025-01-31 오후 4 00 30" src="https://github.com/user-attachments/assets/b5a0e605-ff1a-489e-9391-a49874db944a" />

- 사진 수정 후
<img width="759" alt="스크린샷 2025-01-31 오후 4 01 24" src="https://github.com/user-attachments/assets/9e1e2a57-e834-4b11-b291-2e19dc69168d" />

