### PR TITLE
[Feat] 회원 정보 관련 API 수정

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/domain/Users.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Users.java
@@ -47,9 +47,6 @@ public class Users extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String email;
 
-    @Column(length = 13)
-    private String phoneNumber;
-
     @Column(columnDefinition = "TEXT")
     private String profileImage;
 
@@ -69,11 +66,6 @@ public class Users extends BaseEntity {
     // 로그인 관련
 //    private LocalDateTime lastLogin;
 
-    @Column(name = "refresh_token")
-    private String refreshToken;
-
-    private LocalDateTime tokenExpiry;
-
     @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
     private List<Diaries> diariesList = new ArrayList<>();
 
@@ -90,9 +82,6 @@ public class Users extends BaseEntity {
     }
     public void updateEmail(String email) {
         this.email = email;
-    }
-    public void updatePhoneNumber(String phoneNumber) {
-        this.phoneNumber = phoneNumber;
     }
     public void updateProfileImage(String profileImage) {
         this.profileImage = profileImage;

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -13,7 +13,7 @@ public interface UserCommandService {
     UserResponseDTO.RefreshResultDTO refresh(String refreshToken);
     Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request);    // 미구현
     Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
-    Users getUserInfo(Long userId);
+    Users getUserInfo();
     Users updateUserInfo(Long userId, UserRequestDTO.UpdateRequestDTO request);
     void deleteUser(Long userId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -14,6 +14,6 @@ public interface UserCommandService {
     Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request);    // 미구현
     Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
     Users getUserInfo();
-    Users updateUserInfo(Long userId, UserRequestDTO.UpdateRequestDTO request);
+    Users updateUserInfo(UserRequestDTO.UpdateRequestDTO request);
     void deleteUser(Long userId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -15,5 +15,5 @@ public interface UserCommandService {
     Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
     Users getUserInfo();
     Users updateUserInfo(UserRequestDTO.UpdateRequestDTO request);
-    void deleteUser(Long userId);
+    void deleteUser();
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -57,7 +57,6 @@ public class UserCommandServiceImpl implements UserCommandService {
                 .password("testPassword")
                 .loginType(LoginType.REGULAR)
                 .email(LocalDateTime.now() + "@test.com")
-                .phoneNumber("010-0000-0000")
                 .profileImage("testProfileImage")
                 .gender(Gender.MALE)
                 .point(0L)
@@ -177,7 +176,6 @@ public class UserCommandServiceImpl implements UserCommandService {
         // 입력 들어온 값만 업데이트
         request.getNickname().ifPresent(user::updateNickname);
         request.getEmail().ifPresent(user::updateEmail);
-        request.getPhoneNumber().ifPresent(user::updatePhoneNumber);
         request.getProfileImage().ifPresent(user::updateProfileImage);
         request.getPoint().ifPresent(user::updatePoint);
 

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -185,11 +185,9 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public void deleteUser(Long userId) {
-        Users user = userRepository.findById(userId)
+    public void deleteUser() {
+        Users user = userRepository.findById(SecurityUtil.getCurrentUserId())
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
-
-        // 이후 유저에 연관된 모든 데이터 삭제해야함 cascade 설정 필요
 
         userRepository.delete(user);
     }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -170,8 +170,8 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public Users updateUserInfo(Long userId, UserRequestDTO.UpdateRequestDTO request) {
-        Users user = userRepository.findById(userId)
+    public Users updateUserInfo(UserRequestDTO.UpdateRequestDTO request) {
+        Users user = userRepository.findById(SecurityUtil.getCurrentUserId())
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
 
         // 입력 들어온 값만 업데이트

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -164,8 +164,8 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public Users getUserInfo(Long userId) {
-        return userRepository.findById(userId)
+    public Users getUserInfo() {
+        return userRepository.findById(SecurityUtil.getCurrentUserId())
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
     }
 

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryCategoryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryCategoryController.java
@@ -35,7 +35,7 @@ public class DiaryCategoryController {
             summary = "카테고리 생성 api",
             description = "새로운 카테고리를 생성할 때 사용하는 api 입니다.\n카테고리 이름과 색상, 사용자의 id 데이터를 넣어주시면 됩니다.")
 
-    @PostMapping("/")
+    @PostMapping("")
     public ApiResponse<DiaryCategoryResponseDTO.CreateCategoryResultDTO> create(@RequestBody @Valid DiaryCategoryRequestDTO.CreateCategoryDTO request) {
         DiaryCategories diaryCategory = diaryCategoryCommandService.createCategory(request);
         return ApiResponse.onSuccess(DiaryCategoryConverter.toCreateCategoryResultDTO(diaryCategory));

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -146,13 +146,11 @@ public class UserController {
     }
 
     @Operation(summary = "회원 탈퇴", description =
-            "# 회원 탈퇴 API 입니다. 회원의 ID를 입력해주세요."
+            "# 회원 탈퇴 API 입니다."
     )
-    @DeleteMapping("/{userId}")
-    public ApiResponse<Object> deleteUser(
-            @PathVariable Long userId
-    ) {
-        userCommandService.deleteUser(userId);
+    @DeleteMapping("")
+    public ApiResponse<Object> deleteUser() {
+        userCommandService.deleteUser();
         return ApiResponse.onSuccess("");
     }
 

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -120,7 +120,7 @@ public class UserController {
     @Operation(summary = "회원 정보 조회", description =
             "# 회원 정보 조회 API 입니다."
     )
-    @GetMapping("/{userId}")
+    @GetMapping("/info")
     public ApiResponse<UserResponseDTO.UserInfoResultDTO> getUserInfo() {
         Users user = userCommandService.getUserInfo();
         return ApiResponse.onSuccess(

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -131,14 +131,13 @@ public class UserController {
     }
 
     @Operation(summary = "회원 정보 수정", description =
-            "# 회원 정보 수정 API 입니다. 회원의 ID와 수정할 정보를 입력해주세요.\n수정을 원하는 데이터만 보내도 수정 가능합니다."
+            "# 회원 정보 수정 API 입니다. 수정할 정보를 입력해주세요.\n수정을 원하는 데이터만 보내도 수정 가능합니다."
     )
-    @PatchMapping("/{userId}")
+    @PatchMapping("/info")
     public ApiResponse<UserResponseDTO.UserInfoResultDTO> updateUserInfo(
-            @PathVariable Long userId,
             @RequestBody UserRequestDTO.UpdateRequestDTO request
     ) {
-        Users user = userCommandService.updateUserInfo(userId, request);
+        Users user = userCommandService.updateUserInfo(request);
         return ApiResponse.onSuccess(
                 UserConverter.toUserInfoResultDTO(
                         user

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -118,13 +118,11 @@ public class UserController {
     }
 
     @Operation(summary = "회원 정보 조회", description =
-            "# 회원 정보 조회 API 입니다. 회원의 ID를 입력해주세요."
+            "# 회원 정보 조회 API 입니다."
     )
     @GetMapping("/{userId}")
-    public ApiResponse<UserResponseDTO.UserInfoResultDTO> getUserInfo(
-            @PathVariable Long userId
-    ) {
-        Users user = userCommandService.getUserInfo(userId);
+    public ApiResponse<UserResponseDTO.UserInfoResultDTO> getUserInfo() {
+        Users user = userCommandService.getUserInfo();
         return ApiResponse.onSuccess(
                 UserConverter.toUserInfoResultDTO(
                         user

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -68,7 +68,6 @@ public class UserRequestDTO {
         // 입력 값을 선택적으로 받기 위해 Optional 사용
         private Optional<String> nickname = Optional.empty();
         private Optional<String> email = Optional.empty();
-        private Optional<String> phoneNumber = Optional.empty();
         private Optional<String> profileImage = Optional.empty();
         private Optional<Long> point = Optional.empty();
     }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -68,7 +68,6 @@ public class UserResponseDTO {
         Long point;
         UserStatus status;
         Gender gender;
-        String phoneNum;
     }
   
     // 미구현


### PR DESCRIPTION
## #️⃣연관된 이슈
#81 

## 📝작업 내용
- 회원 정보 관련 API 수정 (회원 정보 조회, 수정, 회원 삭제)
- 카테고리 생성 API 경로 수정
- Users 엔티티 컬럼 수정

## 🔎코드 설명
**1. 회원 정보 관련 API 수정** (회원 정보 조회, 수정, 회원 삭제)
userid를 request로 받는 대신 accesstoken에서 추출하여 사용하게 수정 (SecurityUtil.getCurrentUserId() 사용)
api path도 path variable로 userid를 사용하는 대신 수정
- /users/{userId} -> /users/info (조회, 수정)
- /users/{userId} -> /users (삭제)

**2. 카테고리 생성 API 경로 수정**
유저 삭제와 동일하게 형태 통일
- /categories/ -> /categories

**3. Users 엔티티 컬럼 수정**
기능 구현에 따라 불필요한 Users 엔티티의 컬럼 삭제
- phoneNumber (미사용)
- refreshToken (별도 클라우드에 accessToken과 함께 저장)
- tokenExpiry (refreshToken이 없어짐에 따라 불필요해짐)

## 💬고민사항 및 리뷰 요구사항 (Optional)
x

## 비고 (Optional)
x
