### PR TITLE
[Feat]  로그아웃 api기능 구현

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/TtattaBackend/ttatta/config/security/JwtAuthenticationFilter.java
@@ -61,10 +61,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        log.info("--------------------------- JwtVerifyFilter ---------------------------");
+        String authHeader = request.getHeader(jwtHeader);
 
         String requestUri = request.getRequestURI();
-        String authHeader = request.getHeader(jwtHeader);
         String refreshToken = request.getHeader("refreshToken");
 
         // 특정 경로에서만 Refresh Token 처리
@@ -75,7 +74,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     checkAuthorizationHeader(authHeader);   // header 가 올바른 형식인지 체크
                     String token = JwtUtils.getTokenFromHeader(authHeader);
                     Claims claims = jwtUtils.validateTokenOnlySignature(token); // 토큰 검증
-                    Authentication authentication = jwtUtils.getAuthentication(token); // 사용자 인증 정보 생성
+                    Authentication authentication = jwtUtils.getAuthenticationFromExpiredAccessToken(token); // 사용자 인증 정보 생성
                     SecurityContextHolder.getContext().setAuthentication(authentication); // 사용자 인증 정보 저장
                     // refresh token 검증
                     jwtUtils.validateRefreshToken(refreshToken); // 토큰 검증
@@ -83,11 +82,47 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 } catch (Exception e) {
                     Gson gson = new Gson();
                     String json = "";
-                    json = gson.toJson(Map.of("error", e.getMessage()));
+                    if (e instanceof CustomExpiredJwtException) {
+                        json = gson.toJson(Map.of("Token_Expired", e.getMessage()));
+                    } else {
+                        json = gson.toJson(Map.of("error", e.getMessage()));
+                    }
+
+                    response.setContentType("application/json; charset=UTF-8");
+                    PrintWriter printWriter = response.getWriter();
+                    printWriter.println(json);
+                    printWriter.close();
                 }
             }
+            // refreshToken != null 처리해주어야함.
+            return; // return을 해주는게 맞나?? dofilter안해줘도 되나??(try에서 해주고 있어서 필요없어 보임.) 일단 /users/refresh로 요청 들어온 상황이면 아래 상황 필요없어서 return함.
+        }
+
+        try {
+            log.info("------------------------------------------------------");
+            checkAuthorizationHeader(authHeader);   // header 가 올바른 형식인지 체크
+            String accessToken = JwtUtils.getTokenFromHeader(authHeader);
+            jwtUtils.validateToken(accessToken); // 토큰 검증
+            jwtUtils.isTokenBlacklisted(authHeader); // 🚨 블랙리스트 확인
+        } catch (Exception e) {
+            Gson gson = new Gson();
+            String json = "";
+            if (e instanceof CustomExpiredJwtException) {
+                json = gson.toJson(Map.of("Token_Expired", e.getMessage()));
+            } else {
+                json = gson.toJson(Map.of("error", e.getMessage()));
+            }
+
+            response.setContentType("application/json; charset=UTF-8");
+            PrintWriter printWriter = response.getWriter();
+            printWriter.println(json);
+            printWriter.close();
+
             return;
         }
+        // accessToken != null 처리해주어야함.
+
+        log.info("--------------------------- JwtVerifyFilter ---------------------------");
 
         try {
             checkAuthorizationHeader(authHeader);   // header 가 올바른 형식인지 체크

--- a/src/main/java/TtattaBackend/ttatta/jwt/JwtUtils.java
+++ b/src/main/java/TtattaBackend/ttatta/jwt/JwtUtils.java
@@ -10,6 +10,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -29,6 +30,7 @@ public class JwtUtils {
 
     @Value("${jwt.secret}")
     public String secretKey;
+    private final RedisTemplate<String, String> redisTemplate;
 
     // 헤더에 "Bearer XXX" 형식으로 담겨온 토큰을 추출한다
     public static String getTokenFromHeader(String header) {
@@ -78,6 +80,16 @@ public class JwtUtils {
         return claim;
     }
 
+    public Authentication getAuthenticationFromExpiredAccessToken(String token) { // context에 넣을 Authentication를 jwt의 userId를 넣어 생성 // static 제거
+        Map<String, Object> claims = validateTokenOnlySignature(token);
+        System.out.println("userId type: " + (claims.get("userId") != null ? claims.get("userId").getClass().getName() : "null"));
+
+//        String email = (String) claims.get("email");
+        Long userId = ((Integer) claims.get("userId")).longValue();
+
+        return new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+    }
+
     public Claims validateTokenOnlySignature(String token) { // static 제거
         Claims claims = null;
         try {
@@ -88,7 +100,7 @@ public class JwtUtils {
                     .parseClaimsJws(token) // 파싱 및 검증, 실패 시 에러
                     .getBody();
         } catch(ExpiredJwtException expiredJwtException){
-            return claims;
+            return expiredJwtException.getClaims(); // ✅ 만료된 토큰에서도 Claims 추출
         } catch(Exception e){
             throw new CustomJwtException("Error access token 검증 못함");
         }
@@ -122,9 +134,33 @@ public class JwtUtils {
     }
 
     // 토큰의 남은 만료시간 계산
-    public long tokenRemainTime(Integer expTime) { // static 제거
-        Date expDate = new Date((long) expTime * (1000));
+    public long tokenRemainTimeSecond(String header) { // static 제거
+        String accessToken = getTokenFromHeader(header);
+        SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(accessToken)
+                .getBody();
+
+        Date expDate = claims.getExpiration(); // 만료 시간 반환 (Date 타입)
         long remainMs = expDate.getTime() - System.currentTimeMillis();
-        return remainMs / (1000 * 60);
+        return remainMs / 1000;
+    }
+
+    // access token redis의 블랙리스트에서 확인
+    public void isTokenBlacklisted(String accessToken) {
+        Set<String> keys = redisTemplate.keys("blackList:*"); // "blackList:*" 패턴의 모든 Key 검색
+        if (keys == null || keys.isEmpty()) {
+            return; // 블랙리스트가 비어있다면 return
+        }
+
+        // 모든 Key에 대해 해당 Token이 Value로 존재하는지 확인
+        for (String key : keys) {
+            String value = redisTemplate.opsForValue().get(key);
+            if (accessToken.equals(value)) {
+                throw new CustomJwtException("로그아웃된 유저입니다.");
+            }
+        }
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -9,7 +9,7 @@ public interface UserCommandService {
     Users createTestUser();
     Users signUp(UserRequestDTO.SignUpRequestDTO request);
     IsAvailable verifyUsernameOverlap(String username);
-    void logout();
+    void logout(String accessToken);
     UserResponseDTO.UserSignInResultDTO signIn(UserRequestDTO.SignInRequestDTO request);
     UserResponseDTO.RefreshResultDTO refresh(String refreshToken);
     Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request);    // 미구현

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -9,6 +9,7 @@ public interface UserCommandService {
     Users createTestUser();
     Users signUp(UserRequestDTO.SignUpRequestDTO request);
     IsAvailable verifyUsernameOverlap(String username);
+    void logout();
     UserResponseDTO.UserSignInResultDTO signIn(UserRequestDTO.SignInRequestDTO request);
     UserResponseDTO.RefreshResultDTO refresh(String refreshToken);
     Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request);    // 미구현

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -148,6 +148,12 @@ public class UserCommandServiceImpl implements UserCommandService {
         return IsAvailable.UNAVAILABLE;
     }
 
+    @Override
+    public void logout() {
+        // 로그아웃시킬 회원의 redis의 refresh token삭제
+        Long userId = SecurityUtil.getCurrentUserId();
+        redisTemplate.delete(userId.toString());
+    }
 
     // 미구현
     @Override

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -92,6 +92,8 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Override
     @Transactional // ???
     public UserResponseDTO.UserSignInResultDTO signIn(UserRequestDTO.SignInRequestDTO request) {
+        String key;
+
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword());
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
 //        SecurityContextHolder.getContext().setAuthentication(authentication); // 로그인을 한 후 인증 정보를 사용할 일은 없을 것 같다.
@@ -105,9 +107,10 @@ public class UserCommandServiceImpl implements UserCommandService {
         String accessToken = jwtUtils.generateToken(valueMap, accessExpTime);
 
         // 인증 완료 후 jwt토큰(refreshToken) 생성
+        key = "users:" + user.getId().toString();
         String refreshToken = jwtUtils.generateToken(Collections.emptyMap(), refreshExpTime);
-        redisTemplate.opsForValue().set(user.getId().toString(), refreshToken, refreshExpTime, TimeUnit.MINUTES);
-        System.out.println("redis에 저장된 refreshToken: " + (String) redisTemplate.opsForValue().get(user.getId().toString()));
+        redisTemplate.opsForValue().set(key, refreshToken, refreshExpTime, TimeUnit.MINUTES);
+        System.out.println("redis에 저장된 refreshToken: " + (String) redisTemplate.opsForValue().get(key));
 
         return UserConverter.toUserSignInResultDTO(user, accessToken, refreshToken);
     }
@@ -115,14 +118,15 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Override
     public UserResponseDTO.RefreshResultDTO refresh(String refreshToken) {
         Long userId = SecurityUtil.getCurrentUserId();
+        String key = "users:" + userId.toString();
         String accessToken;
         String newRefreshToken;
 
         // 전달된 refresh token과 redis의 refresh token비교
-        String getUserIdFromRedis = redisTemplate.opsForValue().get(userId.toString());
+        String getRefreshTokenFromRedis = redisTemplate.opsForValue().get(key);
         System.out.println("userId: " + userId);
-        System.out.println("redis에서 가져온 refreshToken: " + getUserIdFromRedis);
-        if (refreshToken.equals(getUserIdFromRedis)) {
+        System.out.println("redis에서 가져온 refreshToken: " + getRefreshTokenFromRedis);
+        if (refreshToken.equals(getRefreshTokenFromRedis)) {
             // 인증 완료 후 jwt토큰(accessToken) 생성
             Map<String, Object> valueMap = Map.of(
                     "userId", userId
@@ -130,7 +134,7 @@ public class UserCommandServiceImpl implements UserCommandService {
             accessToken = jwtUtils.generateToken(valueMap, accessExpTime);
             // 인증 완료 후 jwt토큰(refreshToken) 생성
             newRefreshToken = jwtUtils.generateToken(Collections.emptyMap(), refreshExpTime);
-            redisTemplate.opsForValue().set(userId.toString(), newRefreshToken, refreshExpTime, TimeUnit.MINUTES);
+            redisTemplate.opsForValue().set(key, newRefreshToken, refreshExpTime, TimeUnit.MINUTES);
         } else {
             throw new ExceptionHandler(REFRESHTOKEN_NOT_EQUAL);
         }
@@ -149,10 +153,17 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public void logout() {
-        // 로그아웃시킬 회원의 redis의 refresh token삭제
+    public void logout(String accessToken) {
+        // 로그아웃시킬 회원의 refresh token redis에서 삭제
         Long userId = SecurityUtil.getCurrentUserId();
-        redisTemplate.delete(userId.toString());
+        String key = "users:" + userId.toString();
+        redisTemplate.delete(key);
+
+        // 로그아웃시킬 회원의 access token redis의 블랙리스트로 저장
+        key = "blackList:" + userId.toString();
+        long tokenRemainTimeSecond = jwtUtils.tokenRemainTimeSecond(accessToken);
+        redisTemplate.opsForValue().set(key, accessToken, tokenRemainTimeSecond, TimeUnit.SECONDS);
+
     }
 
     // 미구현

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -89,8 +89,10 @@ public class UserController {
             "# 로그아웃 API 입니다. 로그아웃하고자 하는 유저의 access token을 header에 입력해주세요."
     )
     @DeleteMapping("/logout")
-    public ApiResponse<?> logout() {
-        userCommandService.logout();
+    public ApiResponse<?> logout(
+            @RequestHeader("Authorization") String accessToken
+    ) {
+        userCommandService.logout(accessToken);
         return ApiResponse.onSuccess("");
     }
 

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -85,6 +85,15 @@ public class UserController {
         );
     }
 
+    @Operation(summary = "로그아웃 API", description =
+            "# 로그아웃 API 입니다. 로그아웃하고자 하는 유저의 access token을 header에 입력해주세요."
+    )
+    @DeleteMapping("/logout")
+    public ApiResponse<?> logout() {
+        userCommandService.logout();
+        return ApiResponse.onSuccess("");
+    }
+
     // 미구현
     @Operation(summary = "카카오 회원가입", description =
             "# 카카오 회원가입 API 입니다."
@@ -157,19 +166,6 @@ public class UserController {
     ) {
         userCommandService.deleteUser(userId);
         return ApiResponse.onSuccess("");
-    }
-
-    // 미구현
-    @Operation(summary = "로그아웃 API", description =
-            "# 로그아웃 API 입니다. 로그아웃하고자 하는 userId를 body에 입력해주세요."
-    )
-    @DeleteMapping("/logout")
-    public ApiResponse<?> logout(
-            @RequestBody UserRequestDTO.LogoutRequestDTO request
-    ) {
-        return ApiResponse.onSuccess(
-                null
-        );
     }
 
     // 미구현

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -72,15 +72,6 @@ public class UserRequestDTO {
         private Optional<String> profileImage = Optional.empty();
         private Optional<Long> point = Optional.empty();
     }
-      
-    // 미구현
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class LogoutRequestDTO {
-        private Long userId;
-    }  
     
     // 미구현  
     @Getter


### PR DESCRIPTION
## #️⃣연관된 이슈
> #79 

## 📝작업 내용
> ### 로그아웃 api 요청 시 해당 유저의 refresh token을 redis에서 삭제

> ### 로그아웃 api 요청 시 해당 유저의 access token을 redis의 블랙 리스트에 추가하여 추가 된 access token에 대해서는 접근 금지 처리
> 로그아웃 성공 시 화면
> ![image](https://github.com/user-attachments/assets/be09f972-223c-40b9-8f0f-9ffb1364d11d)
> 로그아웃 된 유저의 access token으로 카테고리 생성 api 요청 시 다음과 같은 에러 메세지 나타남.
> ![image](https://github.com/user-attachments/assets/9ee26099-b51b-4e36-bdec-f3dab03bcddb)
> 그리고 access token 만료시 redis의 블랙리스트에서 access token삭제되고 카테고리 생성 api 요청 시 다음과 같은 에러 메세지 나타남.
> ![image](https://github.com/user-attachments/assets/dbc658e2-2b6c-40ba-9b5c-2fce6281e044)
> redis의 블랙 리스트에 access token을 추가할 때 access token의 남은 만료일을 유효기간으로 설정
> access token이 포함된 api 요청시 블랙리스트에 요청 받은 access token 존재 여부 확인(JwtUtils의 isTokenBlacklisted메서드)

> ### redis에 access token을 블랙리스트에 추가 시 refresh token과 구분하기 위해서 access token의 key에는 users를 refresh token의  key에는 blackList를 붙여 구분함

> ### 수정 사항
> refresh token으로 access token을 재발급 받을 때 만료가 된 access token에 대해 발생하는 error무시하도록 수정(JwtUtils의 getAuthenticationFromExpiredAccessToken메서드)

## 🔎코드 설명
> x

## 💬고민사항 및 리뷰 요구사항 (Optional)
> spring security의 jwt필터에서 토큰 갱신 기능과 로그아웃된 access token확인 기능 순서에따라 오류 발생 (일단 해결했지만 리팩토링 필요해 보임.)
> dofilter 및 return 처리
> exception 에러 통일 코드로 처리하기

## 비고 (Optional)
> x
