### PR TITLE
[Feat] 일기 지도 조회 API 

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
@@ -44,14 +44,14 @@ public class DiaryConverter {
     }
 
     public static DiaryResponseDTO.KeepDiaryDTO toKeepDiaryDTO(Diaries diaries) {
-        List<String> imageUrl = diaries.getDiaryPhotosList().stream()
-                .map(DiaryPhotos::getImageUrl).collect(Collectors.toList());
+        String imageUrl = diaries.getDiaryPhotosList().stream()
+                .map(DiaryPhotos::getImageUrl).collect(Collectors.toList()).get(0);
 
         return DiaryResponseDTO.KeepDiaryDTO.builder()
                 .diaryId(diaries.getId())
                 .date(diaries.getDate())
                 .content(diaries.getContent())
-                .image(imageUrl.toString())
+                .image(imageUrl)
                 .locationName(diaries.getLocationName())
                 .build();
     }

--- a/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
@@ -77,6 +77,8 @@ public class DiaryConverter {
                 .date(diaries.getDate())
                 .content(diaries.getContent())
                 .image(imageUrl)
+                .firstDiary(diaryList.isFirst())
+                .lastDiary(diaryList.isLast())
                 .build();
 
     }

--- a/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
@@ -65,13 +65,18 @@ public class DiaryConverter {
                 .build();
     }
 
-    public static DiaryResponseDTO.MapResultDTO toMapResultDTO(Diaries diaries) {
+    public static DiaryResponseDTO.MapResultDTO toMapDiaryDTO(Page<Diaries> diaryList) {
+        Diaries diaries = diaryList.getContent().stream().findFirst().get();
+
+        String imageUrl = diaries.getDiaryPhotosList().stream()
+                .map(DiaryPhotos::getImageUrl).collect(Collectors.toList()).get(0);
+
         return DiaryResponseDTO.MapResultDTO.builder()
                 .diaryId(diaries.getId())
                 .diaryCategoryId(diaries.getDiaryCategories().getId())
                 .date(diaries.getDate())
                 .content(diaries.getContent())
-                .image(diaries.getDiaryPhotosList().toString())
+                .image(imageUrl)
                 .build();
 
     }

--- a/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
@@ -48,6 +48,8 @@ public class Diaries extends BaseEntity {
     @OneToMany(mappedBy = "diaries", cascade = CascadeType.ALL)
     private List<DiaryPhotos> diaryPhotosList = new ArrayList<>();
 
+    private Long clusterId;
+
     public void setUsers(Users users) {
         // 기존에 이미 등록되어 있던 관계를 제거
         if (this.users != null) {

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -26,4 +26,7 @@ public interface DiaryRepository extends JpaRepository<Diaries, Long> {
 
     @Query("SELECT d FROM Diaries d WHERE d.users = :user AND d.content LIKE %:content% ORDER BY d.date DESC")
     Page<Diaries> findAllByUsersAndContent(@Param("user")Users user, @Param("content") String content, PageRequest pageRequest);
+
+    @Query("SELECT d FROM Diaries d WHERE d.users = :user AND d.clusterId = :clusterId ORDER BY d.date DESC" )
+    Page<Diaries> findAllByUsersAndClusterId(@Param("user") Users user, @Param("clusterId") Long clusterId, PageRequest pageRequest);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryService.java
@@ -9,4 +9,5 @@ import java.time.LocalDateTime;
 public interface DiaryQueryService {
     Page<Diaries> getDiaryList(LocalDateTime date, int requestNum);
     Page<Diaries> getSearchDiaryList(String content, int requestNum);
+    Page<Diaries> getMapDiaryList(Long clusterId, int requestNum);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
@@ -50,4 +50,15 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
 
         return diariesPage;
     }
+
+    @Override
+    public Page<Diaries> getMapDiaryList(Long clusterId, int requestNum) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        Users user = userRepository.findById(userId).get();
+
+        Page<Diaries> diariesPage = diaryRepository.findAllByUsersAndClusterId(user, clusterId, PageRequest.of(requestNum, 1));
+
+        return diariesPage;
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -99,7 +99,7 @@ public class DiaryController {
 
     @Operation(summary = "일기 지도",
         description = """
-                clusterId와 페이징 번호를 작성해주세요.
+                clusterId와 페이징 번호(0번 부터 시작)를 작성해주세요.
                 일기 지도 화면에서 발자국 컴포넌트 클릭 시 그 위치의 일기가 1개씩 반환됩니다.
                 """
     )

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -99,14 +99,19 @@ public class DiaryController {
 
     @Operation(summary = "일기 지도",
         description = """
-                위도, 경도, 페이징 번호를 작성해주세요.
-                일기 지도 화면에서 발자국 컴포넌트 클릭 시 그 위치의 일기가 반환됩니다.
+                clusterId와 페이징 번호를 작성해주세요.
+                일기 지도 화면에서 발자국 컴포넌트 클릭 시 그 위치의 일기가 1개씩 반환됩니다.
                 """
     )
     @GetMapping("/map/{requestNum}")
-    public ApiResponse<DiaryResponseDTO.MapResultDTO> getMapDiary (@PathVariable int requestNum,
-                                                                   @RequestBody @Valid DiaryRequestDTO.MapDTO request) {
-        return null;
+    public ApiResponse<DiaryResponseDTO.MapResultDTO> getMapDiary (@RequestParam Long clusterId,
+                                                                   @PathVariable int requestNum) {
+
+        Page<Diaries> diaryList = diaryQueryService.getMapDiaryList(clusterId, requestNum);
+
+        return ApiResponse.onSuccess(
+                DiaryConverter.toMapDiaryDTO(diaryList)
+        );
     }
 
     @Operation(summary = "일기 검색",

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -26,11 +26,4 @@ public class DiaryRequestDTO {
         private Optional<String> content = Optional.empty();
         private Optional<Long> diaryCategoryId = Optional.empty();
     }
-
-
-    @Getter
-    public static class MapDTO {
-        private double latitude;
-        private double longitude;
-    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
@@ -58,6 +58,8 @@ public class DiaryResponseDTO {
         LocalDateTime date;
         String content;
         String image;
+        boolean firstDiary;
+        boolean lastDiary;
     }
 
     @Getter


### PR DESCRIPTION
## #️⃣연관된 이슈
> #84 

## 📝작업 내용
> 발자국 컴포넌트 클릭 시 일기를 최신순으로 1개씩 반환합니다. 

## 🔎코드 설명
> ResponseDTO: 일기 id, 카테고리 id, date, content, image, firstDiary, lastDiary 반환
> findAllByUsersAndClusterId: 유저 별 클러스터 Id가 같은 일기를 반환 date 최신순으로

## 💬고민사항 및 리뷰 요구사항 (Optional)
> firstDiary, lastDiary를 response에 추가했습니다 !
> 페이징 번호가 일기 개수를 초과해서 요청이 들어오면 에러 발생
> 그래서 첫번째 일기인지 or 마지막 일기 인지를 같이 보내줘서 그 범위를 넘어가는 페이지 요청이 들어오지 않게 하기 위해서 입니다 ! 

## DB
> 클러스터 id 중심으로 확인하면 됩니다 :)
<img width="322" alt="스크린샷 2025-02-04 오후 5 47 02" src="https://github.com/user-attachments/assets/fd751ce5-936f-4721-adb1-378409822968" />

## Swagger
> clusterId: 0 requestNum: 0 (가장 나중에 쓴 일기)
<img width="192" alt="스크린샷 2025-02-04 오후 5 48 12" src="https://github.com/user-attachments/assets/46c18034-9a17-4783-9bea-033630897344" />

> clusterId: 0, requestNum: 1
<img width="187" alt="스크린샷 2025-02-04 오후 5 48 48" src="https://github.com/user-attachments/assets/8dca2678-15af-4215-bf25-f4d78891b6cf" />

> clusterId: 0, requestNum: 3 (가장 먼저 쓴 일기)
<img width="187" alt="스크린샷 2025-02-04 오후 5 49 18" src="https://github.com/user-attachments/assets/b219cf52-aa93-4cfb-a5e8-f5113053b2fb" />

----------------------------------- 다른 장소 ------------------------------------- 
> clusterId: 1, requestNum: 0
<img width="182" alt="스크린샷 2025-02-04 오후 5 50 32" src="https://github.com/user-attachments/assets/073f7e3d-45c9-4ecd-b201-1c3b86521ab7" />

> clusterId: 1, requestNum: 1
<img width="188" alt="스크린샷 2025-02-04 오후 5 51 04" src="https://github.com/user-attachments/assets/d2361b6e-e77d-48fd-90ac-6196c2276e37" />
