### PR TITLE
[Feat] 카테고리 별 발자국 조회 및 일기 조회

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -64,4 +64,7 @@ public interface DiaryRepository extends JpaRepository<Diaries, Long> {
 
     @Query("SELECT d FROM Diaries d WHERE d.users = :user AND d.clusterId = :clusterId ORDER BY d.date DESC" )
     Page<Diaries> findAllByUsersAndClusterId(@Param("user") Users user, @Param("clusterId") Long clusterId, PageRequest pageRequest);
+
+    @Query("SELECT d FROM Diaries d WHERE d.users = :user AND d.clusterId = :clusterId AND d.diaryCategories = :diaryCategories ORDER BY d.date DESC" )
+    Page<Diaries> findAllByUsersAndClusterIdAndCategories(@Param("user") Users user, @Param("clusterId") Long clusterId, @Param("diaryCategories") DiaryCategories diaryCategories, PageRequest pageRequest);
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -40,6 +40,17 @@ public interface DiaryRepository extends JpaRepository<Diaries, Long> {
             ")")
     List<Diaries> findAllByUsers(@Param("user") Users user);
 
+    @Query("SELECT d " +
+            "FROM Diaries d " +
+            "WHERE d.users = :user " +
+            "AND d.diaryCategories = :diaryCategories " +
+            "AND d.date = ( " +
+            "    SELECT MAX(d2.date) " +
+            "    FROM Diaries d2 " +
+            "    WHERE d2.users = :user " +
+            "    AND d2.clusterId = d.clusterId " +
+            ")")
+    List<Diaries> findDiariesByUsersAndCategories(@Param("user") Users user, @Param("diaryCategories") DiaryCategories diaryCategories);
 
     @Query("SELECT d.clusterId " +
             "FROM Diaries d " +

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryService.java
@@ -10,5 +10,5 @@ public interface DiaryQueryService {
     List<Diaries> getFootprintDiaryList(Long diaryCategoryId);
     Page<Diaries> getDiaryList(LocalDateTime date, int requestNum);
     Page<Diaries> getSearchDiaryList(String content, int requestNum);
-    Page<Diaries> getMapDiaryList(Long clusterId, int requestNum);
+    Page<Diaries> getMapDiaryList(Long clusterId, Long diaryCategoryId, int requestNum);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryService.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface DiaryQueryService {
-    List<Diaries> getFootprintDiaryList();
+    List<Diaries> getFootprintDiaryList(Long diaryCategoryId);
     Page<Diaries> getDiaryList(LocalDateTime date, int requestNum);
     Page<Diaries> getSearchDiaryList(String content, int requestNum);
     Page<Diaries> getMapDiaryList(Long clusterId, int requestNum);

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
@@ -3,7 +3,9 @@ package TtattaBackend.ttatta.service.DiaryService;
 
 import TtattaBackend.ttatta.config.security.SecurityUtil;
 import TtattaBackend.ttatta.domain.Diaries;
+import TtattaBackend.ttatta.domain.DiaryCategories;
 import TtattaBackend.ttatta.domain.Users;
+import TtattaBackend.ttatta.repository.DiaryCategoryRepository;
 import TtattaBackend.ttatta.repository.DiaryRepository;
 import TtattaBackend.ttatta.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +14,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -24,13 +26,22 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
 
     private final UserRepository userRepository;
 
+    private final DiaryCategoryRepository diaryCategoryRepository;
+
     @Override
-    public List<Diaries> getFootprintDiaryList(){
+    public List<Diaries> getFootprintDiaryList(Long diaryCategoryId){
         Long userId = SecurityUtil.getCurrentUserId();
 
         Users user =  userRepository.findById(userId).get();
 
-        List<Diaries> diariesList = diaryRepository.findAllByUsers(user);
+        List<Diaries> diariesList;
+
+        if(diaryCategoryId == null) {
+            diariesList = diaryRepository.findAllByUsers(user);
+        } else {
+            DiaryCategories diaryCategories = diaryCategoryRepository.findById(diaryCategoryId).get();
+            diariesList = diaryRepository.findDiariesByUsersAndCategories(user, diaryCategories);
+        }
 
         return diariesList;
 

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
@@ -76,12 +76,19 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
     }
 
     @Override
-    public Page<Diaries> getMapDiaryList(Long clusterId, int requestNum) {
+    public Page<Diaries> getMapDiaryList(Long clusterId, Long diaryCategoryId, int requestNum) {
         Long userId = SecurityUtil.getCurrentUserId();
 
         Users user = userRepository.findById(userId).get();
 
-        Page<Diaries> diariesPage = diaryRepository.findAllByUsersAndClusterId(user, clusterId, PageRequest.of(requestNum, 1));
+        Page<Diaries> diariesPage;
+
+        if(diaryCategoryId == null) {
+            diariesPage = diaryRepository.findAllByUsersAndClusterId(user, clusterId, PageRequest.of(requestNum, 1));
+        } else {
+            DiaryCategories diaryCategories = diaryCategoryRepository.findById(diaryCategoryId).get();
+            diariesPage = diaryRepository.findAllByUsersAndClusterIdAndCategories(user, clusterId, diaryCategories, PageRequest.of(requestNum, 1));
+        }
 
         return diariesPage;
     }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -82,12 +82,13 @@ public class DiaryController {
 
     @Operation(summary = "일기 지도(발자국) 전체 조회",
             description = """
-                    지도 화면에서 발자국 표현을 위한 일기 전체 조회입니다.
+                    지도 화면에서 발자국 표현을 위한 일기 전체 조회입니다.\n
+                    카테고리 id를 같이 요청(선택)하면 그 카테고리에 포함된 일기의 발자국 표시가 가능합니다.
                     """
     )
     @GetMapping("/footprint")
-    public ApiResponse<DiaryResponseDTO.FootprintDiaryListDTO> getFootprintDiaryList() {
-        List<Diaries> diariesList = diaryQueryService.getFootprintDiaryList();
+    public ApiResponse<DiaryResponseDTO.FootprintDiaryListDTO> getFootprintDiaryList(@RequestParam(required = false) Long diaryCategoryId) {
+        List<Diaries> diariesList = diaryQueryService.getFootprintDiaryList(diaryCategoryId);
 
         return ApiResponse.onSuccess(
                 DiaryConverter.toFootprintDiaryListDTO(diariesList)

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -115,15 +115,18 @@ public class DiaryController {
 
     @Operation(summary = "일기 지도",
         description = """
-                clusterId와 페이징 번호(0번 부터 시작)를 작성해주세요.
-                일기 지도 화면에서 발자국 컴포넌트 클릭 시 그 위치의 일기가 1개씩 반환됩니다.
+                clusterId와 페이징 번호(0번 부터 시작)를 작성해주세요.\n
+                일기 지도 화면에서 발자국 컴포넌트 클릭 시 그 위치의 일기가 1개씩 반환됩니다.\n
+                카테고리 Id가 같이 요청(선택) 될 시 해당 카테고리의 일기만 1개씩 반환됩니다.
+                반환 값에 firstDiary와 lastDiary로 boolean 값을 추가했습니다 ! 해당 범위 내에 있는 일기만 페이징 요청 부탁드립니다 :)
                 """
     )
     @GetMapping("/map/{requestNum}")
     public ApiResponse<DiaryResponseDTO.MapResultDTO> getMapDiary (@RequestParam Long clusterId,
+                                                                   @RequestParam(required = false) Long diaryCategoryId,
                                                                    @PathVariable int requestNum) {
 
-        Page<Diaries> diaryList = diaryQueryService.getMapDiaryList(clusterId, requestNum);
+        Page<Diaries> diaryList = diaryQueryService.getMapDiaryList(clusterId,diaryCategoryId, requestNum);
 
         return ApiResponse.onSuccess(
                 DiaryConverter.toMapDiaryDTO(diaryList)


### PR DESCRIPTION
## #️⃣연관된 이슈
> #89 

## 📝작업 내용
> 특정 카테고리 선택 시 그 카테고리에 해당하는 일기만 발자국 조회 가능
> 카테고리 선택 후 발자국 선택 시 카테고리에 해당하는 일기만 1개씩 조회 가능

## 🔎코드 설명
> findDiariesByUsersAndCategories: 유저, 카테고리가 동일하고, 같은 장소 시 가장 최근 날짜의 일기 정보를 반환
> findAllByUsersAndClusterIdAndCategories: 유저, 카테고리 동일, 같은 장소시 최신순으로 page 반환

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 원래 diaryCategoryId를 path variable로 받으려고 했었는데, 그럼 diaryCategoryId가 없을 경우 url 매핑이 안돼서 request param으로 수정했습니다. -> 명세서 반영 완료

## DB
> 카테고리 1, 2 존재 clusterId 0,1,2,3,4,5 존재
<img width="535" alt="스크린샷 2025-02-05 오후 11 29 35" src="https://github.com/user-attachments/assets/245b2ff5-1a28-4e41-987c-ff17bc4e40de" />

## Swagger(일기 발자국)
> 카테고리 id 없을 경우 ➡️ 카테고리 id 상관없이 clusterId로 최신순 1개씩 반환
<img width="265" alt="스크린샷 2025-02-05 오후 11 30 59" src="https://github.com/user-attachments/assets/d3723a12-73ad-4619-8d7b-1830f1c4b6b8" />

> 카테고리 id 1 ➡️ 카테고리 1인 일기 중 clusterId로 같은 장소 중 최신순 1개씩 반환
<img width="214" alt="스크린샷 2025-02-05 오후 11 32 29" src="https://github.com/user-attachments/assets/64dc63b4-3cd1-4a93-90aa-2cc34ef7b341" />

> 카테고리 id 2 ➡️ 카테고리 2인 일기 중 clusterId로 같은 장소 중 최신순 1개씩 반환
<img width="269" alt="스크린샷 2025-02-05 오후 11 34 19" src="https://github.com/user-attachments/assets/69aa4308-2d1a-4069-b500-5939f183290b" />

## Swagger(일기 지도)
> 같은 장소(clusterId는 같고)인데 카테고리(categoryId는 다를 경우)가 다를 경우 test
<img width="538" alt="스크린샷 2025-02-05 오후 11 38 00" src="https://github.com/user-attachments/assets/eb9b92fc-07dc-4370-8588-087bff3ab31f" />

> clusterId: 3, diaryCategoryId: 1
<img width="163" alt="스크린샷 2025-02-05 오후 11 38 47" src="https://github.com/user-attachments/assets/38efb118-0718-4529-998b-b0e20f683e29" />

> clusterId: 3, diaryCateogryId: 2
<img width="169" alt="스크린샷 2025-02-05 오후 11 39 14" src="https://github.com/user-attachments/assets/45969045-9459-4910-8d97-6c3d072514d9" />

