### PR TITLE
[Feat] Item 도메인 수정 및 ENUM 추가

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/domain/Items.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Items.java
@@ -2,6 +2,7 @@ package TtattaBackend.ttatta.domain;
 
 
 import TtattaBackend.ttatta.domain.common.BaseEntity;
+import TtattaBackend.ttatta.domain.enums.BodyPart;
 import TtattaBackend.ttatta.domain.enums.CharacterType;
 import TtattaBackend.ttatta.domain.mapping.OwnedItems;
 import jakarta.persistence.*;
@@ -35,6 +36,9 @@ public class Items extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private CharacterType characterType;
+
+    @Enumerated(EnumType.STRING)
+    private BodyPart bodyPart;
 
     @OneToMany(mappedBy = "items",cascade = CascadeType.ALL)
     private List<OwnedItems> ownedItemsList = new ArrayList<>();

--- a/src/main/java/TtattaBackend/ttatta/domain/enums/BodyPart.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/enums/BodyPart.java
@@ -1,0 +1,5 @@
+package TtattaBackend.ttatta.domain.enums;
+
+public enum BodyPart {
+    HEAD, TORSO
+}


### PR DESCRIPTION
Items에 BodyPart 필드 추가 및 BodyPart ENUM(Head, torso) 추가

## #️⃣연관된 이슈
> #91 

## 📝작업 내용
> BodyPart ENUM: HEAD, TORSO

## 🔎코드 설명
> 아이템 저장 시 몸통과 머리를 구분하는 ENUM을 추가했습니다.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
