### PR TITLE
[Feat] 미소유 아이템(shop) 조회 기능 구현

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/ItemConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/ItemConverter.java
@@ -7,6 +7,9 @@ import TtattaBackend.ttatta.domain.mapping.OwnedItems;
 import TtattaBackend.ttatta.web.dto.ItemRequestDTO;
 import TtattaBackend.ttatta.web.dto.ItemResponseDTO;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class ItemConverter {
 
     public static ItemResponseDTO.MakeItemResultDTO toMakeItemResultDTO(Items item) {
@@ -43,6 +46,27 @@ public class ItemConverter {
         return ItemResponseDTO.ItemEquipResultDTO.builder()
                 .itemId(ownedItems.getId())
                 .isEquipped(true)
+                .build();
+    }
+
+    public static ItemResponseDTO.ItemShopDTO toItemShopDTO(Items items) {
+        return ItemResponseDTO.ItemShopDTO.builder()
+                .itemId(items.getId())
+                .name(items.getName())
+                .cost(items.getCost())
+                .itemImage(items.getItemImg())
+                .characterType(items.getCharacterType())
+                .bodyPart(items.getBodyPart())
+                .build();
+    }
+
+    public static ItemResponseDTO.ItemShopListDTO toItemShopListDTO(List<Items> itemsList, Long point) {
+        List<ItemResponseDTO.ItemShopDTO> toItemShopListDTO = itemsList.stream()
+                .map(ItemConverter::toItemShopDTO).collect(Collectors.toList());
+
+        return ItemResponseDTO.ItemShopListDTO.builder()
+                .point(point)
+                .itemShopList(toItemShopListDTO)
                 .build();
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/ItemRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/ItemRepository.java
@@ -1,9 +1,18 @@
 package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.Items;
+import TtattaBackend.ttatta.domain.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ItemRepository extends JpaRepository<Items, Long> {
+    @Query("SELECT i FROM Items i " +
+            "WHERE NOT EXISTS (SELECT o FROM OwnedItems o WHERE o.users = :user AND o.items.id = i.id)")
+    List<Items> getShopItem(@Param("user") Users user);
+
 }

--- a/src/main/java/TtattaBackend/ttatta/service/ItemService/ItemQueryService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/ItemService/ItemQueryService.java
@@ -1,0 +1,10 @@
+package TtattaBackend.ttatta.service.ItemService;
+
+import TtattaBackend.ttatta.domain.Items;
+
+import java.util.List;
+
+public interface ItemQueryService {
+    List<Items> getShopItem();
+
+}

--- a/src/main/java/TtattaBackend/ttatta/service/ItemService/ItemQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/ItemService/ItemQueryServiceImpl.java
@@ -1,0 +1,35 @@
+package TtattaBackend.ttatta.service.ItemService;
+
+import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
+import TtattaBackend.ttatta.config.security.SecurityUtil;
+import TtattaBackend.ttatta.domain.Items;
+import TtattaBackend.ttatta.domain.Users;
+import TtattaBackend.ttatta.repository.ItemRepository;
+import TtattaBackend.ttatta.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.USER_NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ItemQueryServiceImpl implements ItemQueryService{
+
+    private final UserRepository userRepository;
+
+    private final ItemRepository itemRepository;
+
+    @Override
+    public List<Items> getShopItem() {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+         return itemRepository.getShopItem(user);
+    }
+
+}

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -17,4 +17,5 @@ public interface UserCommandService {
     Users getUserInfo();
     Users updateUserInfo(UserRequestDTO.UpdateRequestDTO request);
     void deleteUser();
+    Long getUserPoint();
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package TtattaBackend.ttatta.service.UserService;
 
+import TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus;
 import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
 import TtattaBackend.ttatta.config.security.SecurityUtil;
 import TtattaBackend.ttatta.converter.DiaryCategoryConverter;
@@ -205,5 +206,13 @@ public class UserCommandServiceImpl implements UserCommandService {
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
 
         userRepository.delete(user);
+    }
+
+    @Override
+    public Long getUserPoint() {
+        Users user = userRepository.findById(SecurityUtil.getCurrentUserId())
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        return user.getPoint();
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/ItemController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/ItemController.java
@@ -4,11 +4,14 @@ import TtattaBackend.ttatta.apiPayload.ApiResponse;
 import TtattaBackend.ttatta.converter.ItemConverter;
 import TtattaBackend.ttatta.domain.Items;
 import TtattaBackend.ttatta.service.ItemService.ItemCommandService;
+import TtattaBackend.ttatta.service.ItemService.ItemQueryService;
+import TtattaBackend.ttatta.service.UserService.UserCommandService;
 import TtattaBackend.ttatta.web.dto.ItemRequestDTO;
 import TtattaBackend.ttatta.web.dto.ItemResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,6 +19,10 @@ import org.springframework.web.bind.annotation.*;
 public class ItemController {
 
     private final ItemCommandService itemCommandService;
+
+    private final ItemQueryService itemQueryService;
+
+    private final UserCommandService userCommandService;
 
     @Operation(summary = "아이템 생성 api",
             description = "아이템을 생성하는 api 에요. 아자아자 파이팅")
@@ -39,4 +46,16 @@ public class ItemController {
         return ApiResponse.onSuccess(itemCommandService.equipItem(itemId));
     }
 
+
+    @Operation(summary = "미소유 아이템 (shop) api",
+            description = "shop 화면에서 사용자가 구매하지 않은 아이템을 반환하는 API 입니다.")
+    @PatchMapping("/shop")
+    public ApiResponse<ItemResponseDTO.ItemShopListDTO> shop () {
+        List<Items> itemsList = itemQueryService.getShopItem();
+        Long point = userCommandService.getUserPoint();
+
+        return ApiResponse.onSuccess(
+                ItemConverter.toItemShopListDTO(itemsList, point)
+        );
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/ItemController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/ItemController.java
@@ -49,7 +49,7 @@ public class ItemController {
 
     @Operation(summary = "미소유 아이템 (shop) api",
             description = "shop 화면에서 사용자가 구매하지 않은 아이템을 반환하는 API 입니다.")
-    @PatchMapping("/shop")
+    @GetMapping("/shop")
     public ApiResponse<ItemResponseDTO.ItemShopListDTO> shop () {
         List<Items> itemsList = itemQueryService.getShopItem();
         Long point = userCommandService.getUserPoint();

--- a/src/main/java/TtattaBackend/ttatta/web/dto/ItemResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/ItemResponseDTO.java
@@ -1,10 +1,13 @@
 package TtattaBackend.ttatta.web.dto;
 
+import TtattaBackend.ttatta.domain.enums.BodyPart;
 import TtattaBackend.ttatta.domain.enums.CharacterType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 public class ItemResponseDTO {
 
@@ -38,5 +41,27 @@ public class ItemResponseDTO {
     public static class ItemEquipResultDTO {
         private Long itemId;
         private Boolean isEquipped;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemShopListDTO {
+        private Long point;
+        private List<ItemShopDTO> itemShopList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemShopDTO {
+        private Long itemId;
+        private String name;
+        private Long cost;
+        private String itemImage;
+        private CharacterType characterType;
+        private BodyPart bodyPart;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #95 

## 📝작업 내용
> 사용자가 구매하지 않은 아이템을 리스트로 반환하는 기능 구현

## 🔎코드 설명
> repository:  아이템 리스트를 반환 -> 조건: 내가 가지고 있는 아이템 제외

## 💬고민사항 및 리뷰 요구사항 (Optional)
> user point를 같이 넘겨줘야해서 getUserPoint라는 메서드를 따로 만들었음
> user 관련 로직이라 userCommandServiceImpl에 구현하고 ItemController에서 userCommandService를 호출해서 쓰게 했는데
> 그냥 itemQueryServiceImpl에서 구현을 할지 고민입니다.

## DB
> 아이템 총 4개 있는 상황
> 유저 1: 아이템 1,3번 구매 / 유저2: 아이템 1,2번 구매 상황
<img width="469" alt="스크린샷 2025-02-07 오전 1 13 39" src="https://github.com/user-attachments/assets/8dc8ffe5-1cb0-4112-b475-06c4d391c7d9" />

## Swagger
> 유저 1이 shop에 들어가면 구매하지 않은 2번 4번 반환
<img width="269" alt="스크린샷 2025-02-07 오전 1 15 05" src="https://github.com/user-attachments/assets/6e10dde3-09eb-42ab-9feb-b2bfbd4b923e" />

> 유저 2가 shop에 들어가면 구매하지 않은 3번 4번 반환
<img width="305" alt="스크린샷 2025-02-07 오전 1 16 11" src="https://github.com/user-attachments/assets/ab777442-cdd5-4bb2-9da1-bbb388c3da93" />
