### PR TITLE
[Feat] 전체 일기 날짜 중복없이  조회 api

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
@@ -6,6 +6,8 @@ import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
 import TtattaBackend.ttatta.web.dto.DiaryResponseDTO;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -123,6 +125,21 @@ public class DiaryConverter {
 
         return DiaryResponseDTO.SearchDiaryListDTO.builder()
                 .searchDiaryList(searchDiaryList)
+                .build();
+    }
+
+    public static DiaryResponseDTO.DiaryDateDTO toDiaryDateDTO(LocalDateTime diaryDate) {
+        return DiaryResponseDTO.DiaryDateDTO.builder()
+                .date(diaryDate.toLocalDate())
+                .build();
+    }
+
+    public static DiaryResponseDTO.DairyDateListResultDTO toDairyDateListResultDTO(List<LocalDateTime> diaryDateList) {
+        List<DiaryResponseDTO.DiaryDateDTO> dairyDateListResultDTOList = diaryDateList.stream()
+                .map(DiaryConverter::toDiaryDateDTO).collect(Collectors.toList());
+
+        return DiaryResponseDTO.DairyDateListResultDTO.builder()
+                .diaryDateList(dairyDateListResultDTOList)
                 .build();
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -67,4 +68,7 @@ public interface DiaryRepository extends JpaRepository<Diaries, Long> {
 
     @Query("SELECT d FROM Diaries d WHERE d.users = :user AND d.clusterId = :clusterId AND d.diaryCategories = :diaryCategories ORDER BY d.date DESC" )
     Page<Diaries> findAllByUsersAndClusterIdAndCategories(@Param("user") Users user, @Param("clusterId") Long clusterId, @Param("diaryCategories") DiaryCategories diaryCategories, PageRequest pageRequest);
+
+    @Query("SELECT DISTINCT d.date FROM Diaries d WHERE d.users = :user ORDER BY d.date DESC")
+    List<LocalDateTime> findDistinctDatesByUser(@Param("user") Users user);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryService.java
@@ -3,6 +3,7 @@ package TtattaBackend.ttatta.service.DiaryService;
 import TtattaBackend.ttatta.domain.Diaries;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -11,4 +12,5 @@ public interface DiaryQueryService {
     Page<Diaries> getDiaryList(LocalDateTime date, int requestNum);
     Page<Diaries> getSearchDiaryList(String content, int requestNum);
     Page<Diaries> getMapDiaryList(Long clusterId, Long diaryCategoryId, int requestNum);
+    List<LocalDateTime> getDiaryDateList();
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -91,5 +92,12 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
         }
 
         return diariesPage;
+    }
+
+    @Override
+    public List<LocalDateTime> getDiaryDateList() {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Users user = userRepository.findById(userId).get();
+        return diaryRepository.findDistinctDatesByUser(user);
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
@@ -1,6 +1,8 @@
 package TtattaBackend.ttatta.service.DiaryService;
 
 
+import TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus;
+import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
 import TtattaBackend.ttatta.config.security.SecurityUtil;
 import TtattaBackend.ttatta.domain.Diaries;
 import TtattaBackend.ttatta.domain.DiaryCategories;
@@ -97,7 +99,7 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
     @Override
     public List<LocalDateTime> getDiaryDateList() {
         Long userId = SecurityUtil.getCurrentUserId();
-        Users user = userRepository.findById(userId).get();
+        Users user = userRepository.findById(userId).orElseThrow(() -> new ExceptionHandler(ErrorStatus.USER_NOT_FOUND));
         return diaryRepository.findDistinctDatesByUser(user);
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/DiaryController.java
@@ -17,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -147,6 +148,21 @@ public class DiaryController {
 
         return ApiResponse.onSuccess(
                 DiaryConverter.toSearchDiaryListDTO(searchDiaryList)
+        );
+    }
+
+    @Operation(summary = "전체 일기 날짜 조회",
+            description = """
+                    캘린더에 표시하기 위해 전체 일기의 날짜를 중복없이 조회하는 API입니다.\n
+                    header에 access token을 포함시켜 주세요.
+                    """
+    )
+    @GetMapping("/date")
+    public ApiResponse<DiaryResponseDTO.DairyDateListResultDTO> getDiariesDate() {
+        List<LocalDateTime> diaryDateList = diaryQueryService.getDiaryDateList();
+
+        return ApiResponse.onSuccess(
+                DiaryConverter.toDairyDateListResultDTO(diaryDateList)
         );
     }
 

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -100,5 +101,21 @@ public class DiaryResponseDTO {
         String content;
         String image;
         String locationName;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DairyDateListResultDTO {
+        List<DiaryDateDTO> diaryDateList;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DiaryDateDTO {
+        LocalDate date;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #98 

## 📝작업 내용
> 전체 일기 날짜 중복없이  조회 api

## 🔎코드 설명
> diaryRespository에서 중복없이 일기의 날짜리스트를 조회해옴.
> 스웨거에서 날짜 조회 api실행 결과
> ![image](https://github.com/user-attachments/assets/a6c310aa-e662-4943-9bc9-81b551c64581)

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
