### PR TITLE
[Feat] 회원 정보 조회 API 수정

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -54,8 +54,21 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.UserInfoResultDTO toUserInfoResultDTO(Users users) {
+    public static UserResponseDTO.UserInfoResultDTO toUserInfoResultDTO(Users users, long diaryCount) {
         return UserResponseDTO.UserInfoResultDTO.builder()
+                .userId(users.getId())
+                .nickname(users.getNickname())
+                .loginType(users.getLoginType())
+                .email(users.getEmail())
+                .profileImg(users.getProfileImage())
+                .point(users.getPoint())
+                .status(users.getStatus())
+                .diaryCount(diaryCount)
+                .build();
+    }
+
+    public static UserResponseDTO.UserInfoEditResultDTO toUserInfoEditResultDTO(Users users) {
+        return UserResponseDTO.UserInfoEditResultDTO.builder()
                 .userId(users.getId())
                 .nickname(users.getNickname())
                 .loginType(users.getLoginType())

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -67,4 +67,8 @@ public interface DiaryRepository extends JpaRepository<Diaries, Long> {
 
     @Query("SELECT d FROM Diaries d WHERE d.users = :user AND d.clusterId = :clusterId AND d.diaryCategories = :diaryCategories ORDER BY d.date DESC" )
     Page<Diaries> findAllByUsersAndClusterIdAndCategories(@Param("user") Users user, @Param("clusterId") Long clusterId, @Param("diaryCategories") DiaryCategories diaryCategories, PageRequest pageRequest);
+
+    // 유저별 일기 개수 조회
+    @Query("SELECT COUNT(d) FROM Diaries d WHERE d.users = :user")
+    long countByUsers(@Param("user") Users user);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -14,7 +14,7 @@ public interface UserCommandService {
     UserResponseDTO.RefreshResultDTO refresh(String refreshToken);
     Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request);    // 미구현
     Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
-    Users getUserInfo();
-    Users updateUserInfo(UserRequestDTO.UpdateRequestDTO request);
+    UserResponseDTO.UserInfoResultDTO getUserInfo();
+    Users editUserInfo(UserRequestDTO.EditRequestDTO request);
     void deleteUser();
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -9,9 +9,9 @@ import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.domain.enums.*;
 import TtattaBackend.ttatta.jwt.JwtUtils;
 import TtattaBackend.ttatta.repository.DiaryCategoryRepository;
+import TtattaBackend.ttatta.repository.DiaryRepository;
 import TtattaBackend.ttatta.repository.UserRepository;
 import TtattaBackend.ttatta.web.dto.DiaryCategoryRequestDTO;
-import TtattaBackend.ttatta.web.dto.DiaryCategoryResponseDTO;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserResponseDTO;
 import jakarta.transaction.Transactional;
@@ -22,7 +22,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -43,6 +42,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Value("${jwt.REFRESH_EXP_TIME}")
     private int refreshExpTime;
     private final UserRepository userRepository;
+    private final DiaryRepository diaryRepository;
     private final DiaryCategoryRepository diaryCategoryRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
@@ -180,13 +180,17 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public Users getUserInfo() {
-        return userRepository.findById(SecurityUtil.getCurrentUserId())
+    public UserResponseDTO.UserInfoResultDTO getUserInfo() {
+        Users user = userRepository.findById(SecurityUtil.getCurrentUserId())
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        long diaryCount = diaryRepository.countByUsers(user);
+
+        return UserConverter.toUserInfoResultDTO(user, diaryCount);
     }
 
     @Override
-    public Users updateUserInfo(UserRequestDTO.UpdateRequestDTO request) {
+    public Users editUserInfo(UserRequestDTO.EditRequestDTO request) {
         Users user = userRepository.findById(SecurityUtil.getCurrentUserId())
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
 

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -133,11 +133,8 @@ public class UserController {
     )
     @GetMapping("/info")
     public ApiResponse<UserResponseDTO.UserInfoResultDTO> getUserInfo() {
-        Users user = userCommandService.getUserInfo();
         return ApiResponse.onSuccess(
-                UserConverter.toUserInfoResultDTO(
-                        user
-                )
+                userCommandService.getUserInfo()
         );
     }
 
@@ -145,12 +142,12 @@ public class UserController {
             "# 회원 정보 수정 API 입니다. 수정할 정보를 입력해주세요.\n수정을 원하는 데이터만 보내도 수정 가능합니다."
     )
     @PatchMapping("/info")
-    public ApiResponse<UserResponseDTO.UserInfoResultDTO> updateUserInfo(
-            @RequestBody UserRequestDTO.UpdateRequestDTO request
+    public ApiResponse<UserResponseDTO.UserInfoEditResultDTO> editUserInfo(
+            @RequestBody UserRequestDTO.EditRequestDTO request
     ) {
-        Users user = userCommandService.updateUserInfo(request);
+        Users user = userCommandService.editUserInfo(request);
         return ApiResponse.onSuccess(
-                UserConverter.toUserInfoResultDTO(
+                UserConverter.toUserInfoEditResultDTO(
                         user
                 )
         );

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -64,7 +64,7 @@ public class UserRequestDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class UpdateRequestDTO {
+    public static class EditRequestDTO {
         // 입력 값을 선택적으로 받기 위해 Optional 사용
         private Optional<String> nickname = Optional.empty();
         private Optional<String> email = Optional.empty();

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -68,6 +68,22 @@ public class UserResponseDTO {
         Long point;
         UserStatus status;
         Gender gender;
+        Long diaryCount;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserInfoEditResultDTO {
+        Long userId;
+        String nickname;
+        LoginType loginType;
+        String email;
+        String profileImg;
+        Long point;
+        UserStatus status;
+        Gender gender;
     }
   
     // 미구현


### PR DESCRIPTION
## #️⃣연관된 이슈
#102 

## 📝작업 내용
회원 정보 조회 API 수정

## 🔎코드 설명
**1. 회원 정보 조회 API 수정**
회원 정보 조회에서 해당 회원이 작성한 일기 개수를 Diary 테이블을 통해 쿼리문으로 직접 Count하여 반환한다.
![image](https://github.com/user-attachments/assets/e7d2c6bb-2093-4c0b-9560-670d0e2d472a)
정상적으로 일기 개수가 반환됨을 확인하였다.

**2. 회원 정보 수정 API DTO 분리**
기존에는 회원정보조회와 회원정보수정 API의 responseDTO를 같이 사용했었다.
그러나 정보조회 API의 response에 일기 개수가 추가됨에 따라, 정보수정 API에서는 해당 내용을 반환할 필요는 없어보여 따로 분리했다.
정보 수정 관련은 모두 edit이라는 단어를 포함하여 명칭을 수정했다.


## 💬고민사항 및 리뷰 요구사항 (Optional)
x

## 비고 (Optional)
x