### PR TITLE
[Feat] 소유 아이템(myitem) 조회 기능 구현

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/ItemConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/ItemConverter.java
@@ -98,7 +98,7 @@ public class ItemConverter {
 
         return ItemResponseDTO.ItemMyItemListDTO.builder()
                 .point(point)
-                .itemShopList(toItemMyItemListDTO)
+                .myItemList(toItemMyItemListDTO)
                 .build();
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/converter/ItemConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/ItemConverter.java
@@ -76,4 +76,29 @@ public class ItemConverter {
                 .itemShopList(toItemShopListDTO)
                 .build();
     }
+
+    public static ItemResponseDTO.ItemMyItemDTO toItemMyItemDTO(Items items, Boolean isEquipped) {
+        return ItemResponseDTO.ItemMyItemDTO.builder()
+                .itemId(items.getId())
+                .name(items.getName())
+                .itemImage(items.getItemImg())
+                .isEquipped(isEquipped)
+                .characterType(items.getCharacterType())
+                .bodyPart(items.getBodyPart())
+                .build();
+    }
+
+    public static ItemResponseDTO.ItemMyItemListDTO toItemMyItemListDTO(List<Object[]> itemsList, Long point) {
+        List<ItemResponseDTO.ItemMyItemDTO> toItemMyItemListDTO = itemsList.stream()
+                .map(itemArray -> {
+                    Items item = (Items) itemArray[0];
+                    Boolean isEquipped = (Boolean) itemArray[1];
+                    return ItemConverter.toItemMyItemDTO(item, isEquipped);
+                }).collect(Collectors.toList());
+
+        return ItemResponseDTO.ItemMyItemListDTO.builder()
+                .point(point)
+                .itemShopList(toItemMyItemListDTO)
+                .build();
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/converter/ItemConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/ItemConverter.java
@@ -81,8 +81,8 @@ public class ItemConverter {
     public static ItemResponseDTO.ItemMyItemDTO toItemMyItemDTO(Items items, Boolean isEquipped) {
         return ItemResponseDTO.ItemMyItemDTO.builder()
                 .itemId(items.getId())
+                .itemUniqueId(items.getItemUniqueId())
                 .name(items.getName())
-                .itemImage(items.getItemImg())
                 .isEquipped(isEquipped)
                 .characterType(items.getCharacterType())
                 .bodyPart(items.getBodyPart())

--- a/src/main/java/TtattaBackend/ttatta/repository/ItemRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/ItemRepository.java
@@ -15,4 +15,9 @@ public interface ItemRepository extends JpaRepository<Items, Long> {
             "WHERE NOT EXISTS (SELECT o FROM OwnedItems o WHERE o.users = :user AND o.items.id = i.id)")
     List<Items> getShopItem(@Param("user") Users user);
 
+    @Query("SELECT i, o.isEquipped FROM Items i " +
+            "INNER JOIN OwnedItems o " +
+            "ON i.id = o.items.id " +
+            "WHERE o.users = :user")
+    List<Object[]> findByUsers(@Param("user") Users user);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/ItemService/ItemQueryService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/ItemService/ItemQueryService.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface ItemQueryService {
     List<Items> getShopItem();
-
+    List<Object[]> getMyItem();
 }

--- a/src/main/java/TtattaBackend/ttatta/service/ItemService/ItemQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/ItemService/ItemQueryServiceImpl.java
@@ -32,4 +32,12 @@ public class ItemQueryServiceImpl implements ItemQueryService{
          return itemRepository.getShopItem(user);
     }
 
+    @Override
+    public List<Object[]> getMyItem() {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        return itemRepository.findByUsers(user);
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/ItemController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/ItemController.java
@@ -70,4 +70,17 @@ public class ItemController {
                 ItemConverter.toItemShopListDTO(itemsList, point)
         );
     }
+
+    @Operation(summary = "소유 아이템(myitem) api",
+            description = "myitem" +
+                    " 화면에서 사용자가 구매한 아이템을 반환하는 API 입니다.")
+    @GetMapping("/owned")
+    public ApiResponse<ItemResponseDTO.ItemMyItemListDTO> owned() {
+        List<Object[]> itemsList = itemQueryService.getMyItem();
+        Long point = userCommandService.getUserPoint();
+
+        return ApiResponse.onSuccess(
+                ItemConverter.toItemMyItemListDTO(itemsList, point)
+        );
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/ItemResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/ItemResponseDTO.java
@@ -80,7 +80,7 @@ public class ItemResponseDTO {
     @AllArgsConstructor
     public static class ItemMyItemListDTO {
         private Long point;
-        private List<ItemMyItemDTO> itemShopList;
+        private List<ItemMyItemDTO> myItemList;
     }
 
     @Builder

--- a/src/main/java/TtattaBackend/ttatta/web/dto/ItemResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/ItemResponseDTO.java
@@ -89,8 +89,8 @@ public class ItemResponseDTO {
     @AllArgsConstructor
     public static class ItemMyItemDTO {
         private Long itemId;
+        private String itemUniqueId;
         private String name;
-        private String itemImage;
         private CharacterType characterType;
         private BodyPart bodyPart;
         private Boolean isEquipped;

--- a/src/main/java/TtattaBackend/ttatta/web/dto/ItemResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/ItemResponseDTO.java
@@ -73,4 +73,27 @@ public class ItemResponseDTO {
         private CharacterType characterType;
         private BodyPart bodyPart;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemMyItemListDTO {
+        private Long point;
+        private List<ItemMyItemDTO> itemShopList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemMyItemDTO {
+        private Long itemId;
+        private String name;
+        private String itemImage;
+        private CharacterType characterType;
+        private BodyPart bodyPart;
+        private Boolean isEquipped;
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #97 

## 📝작업 내용
> myitem 화면에서 확인할 수 있는 사용자 소유 아이템 반환 기능 구현

## 🔎코드 설명
> repository: 사용자가 가진 아이템들과 착용 여부를 반환

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## DB
> 사용자가 아이템 1,2 구매
<img width="465" alt="스크린샷 2025-02-08 오후 10 05 34" src="https://github.com/user-attachments/assets/2f020f4e-ff2d-47bc-9ab1-d0845a010480" />

## Swagger
> 구매한 아이템의 정보와 착용 여부 반환
<img width="249" alt="스크린샷 2025-02-08 오후 10 09 53" src="https://github.com/user-attachments/assets/81c2df6e-58b5-4dc1-9fd0-5dd6a5ee237e" />

