### PR TITLE
[Feat] 챌린지 성공 api 구현

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/ChallengeConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/ChallengeConverter.java
@@ -23,4 +23,12 @@ public class ChallengeConverter {
                 .createdAt(challenge.getCreatedAt())
                 .build();
     }
+
+    public static ChallengeResponeseDTO.SuccessChallengeResultDTO toSuccessChallengeResultDTO(Challenges challenge) {
+        return ChallengeResponeseDTO.SuccessChallengeResultDTO.builder()
+                .challengId(challenge.getId())
+                .isCompleted(challenge.getIsCompleted())
+                .updatedAt(challenge.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/converter/ChallengeConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/ChallengeConverter.java
@@ -26,7 +26,7 @@ public class ChallengeConverter {
 
     public static ChallengeResponeseDTO.SuccessChallengeResultDTO toSuccessChallengeResultDTO(Challenges challenge) {
         return ChallengeResponeseDTO.SuccessChallengeResultDTO.builder()
-                .challengId(challenge.getId())
+                .challengeId(challenge.getId())
                 .isCompleted(challenge.getIsCompleted())
                 .updatedAt(challenge.getUpdatedAt())
                 .build();

--- a/src/main/java/TtattaBackend/ttatta/domain/Challenges.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Challenges.java
@@ -44,4 +44,8 @@ public class Challenges extends BaseEntity {
             users.getChallengesList().add(this);
         }
     }
+
+    public void updateIsCompleted() {
+        this.isCompleted = true;
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/ChallengeRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/ChallengeRepository.java
@@ -1,6 +1,7 @@
 package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.Challenges;
+import TtattaBackend.ttatta.domain.Users;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,8 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.time.LocalDateTime;
 
 public interface ChallengeRepository extends JpaRepository<Challenges, Long> {
-
     @Query("SELECT COUNT(d) FROM Challenges d WHERE DATE(d.createdAt) = DATE(:targetDate)")
     int countByCreatedAtOn(@Param("targetDate") LocalDateTime targetDate);
-
+    Challenges findByIdAndUsers(Long challengeId, Users user);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/ChallengeService/ChallengeCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/ChallengeService/ChallengeCommandService.java
@@ -5,4 +5,5 @@ import TtattaBackend.ttatta.web.dto.ChallengeRequestDTO;
 
 public interface ChallengeCommandService {
     Challenges createChallenge(ChallengeRequestDTO.CreateChallengeRequestDTO request);
+    Challenges successChallenge(Long challengeId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -46,6 +46,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
         Users getUser = userRepository.findById(userId).orElseThrow(() -> new ExceptionHandler(ErrorStatus.USER_NOT_FOUND));
         Challenges getChallenge = challengeRepository.findByIdAndUsers(challengeId, getUser);
         getChallenge.updateIsCompleted();
+        getUser.updatePoint(getUser.getPoint() + 50);
         return getChallenge;
     }
 

--- a/src/main/java/TtattaBackend/ttatta/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -11,6 +11,7 @@ import TtattaBackend.ttatta.repository.UserRepository;
 import TtattaBackend.ttatta.web.dto.ChallengeRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -21,6 +22,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
     private final ChallengeRepository challengeRepository;
     private final UserRepository userRepository;
 
+    @Override
     public Challenges createChallenge(ChallengeRequestDTO.CreateChallengeRequestDTO request) {
         Long userId = SecurityUtil.getCurrentUserId();
         Users getUser = userRepository.findById(userId).orElseThrow(() -> new ExceptionHandler(ErrorStatus.USER_NOT_FOUND));
@@ -36,4 +38,15 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
         challenge.setUsers(getUser);
         return challengeRepository.save(challenge);
     }
+
+    @Override
+    @Transactional
+    public Challenges successChallenge(Long challengeId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Users getUser = userRepository.findById(userId).orElseThrow(() -> new ExceptionHandler(ErrorStatus.USER_NOT_FOUND));
+        Challenges getChallenge = challengeRepository.findByIdAndUsers(challengeId, getUser);
+        getChallenge.updateIsCompleted();
+        return getChallenge;
+    }
+
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/ChallengeController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/ChallengeController.java
@@ -36,17 +36,17 @@ public class ChallengeController {
         );
     }
 
-//    @Operation(summary = "아이템 구매 api",
-//            description = "아이템을 구매하는 api입니다.\npath path variable 로 구매하려는 아이템 id를 받습니다.")
-//    @PatchMapping("/{itemId}")
-//    public ApiResponse<ItemResponseDTO.ItemBuyResultDTO> buy (@PathVariable Long itemId) {
-//        return ApiResponse.onSuccess(itemCommandService.buyItem(itemId));
-//    }
-//
-//    @Operation(summary = "아이템 착용 api",
-//            description = "아이템을 착용하는 api 입니다.\n path variable로 착용하려는 아이템 id를 받습니다.")
-//    @PatchMapping("/equip/{itemId}")
-//    public ApiResponse<ItemResponseDTO.ItemEquipResultDTO> equip (@PathVariable Long itemId) {
-//        return ApiResponse.onSuccess(itemCommandService.equipItem(itemId));
-//    }
+    @Operation(summary = "챌린지 성공 api",
+            description = "챌린지의 상태를 성공으로 바꾸는 api입니다.\n"
+                    + "header에 access token을 넣어주세요.")
+    @PatchMapping("/{challengeId}")
+    public ApiResponse<ChallengeResponeseDTO.SuccessChallengeResultDTO> successChallenge(
+            @PathVariable Long challengeId
+    ) {
+        return ApiResponse.onSuccess(
+                ChallengeConverter.toSuccessChallengeResultDTO(
+                        challengeCommandService.successChallenge(challengeId)
+                )
+        );
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/ChallengeResponeseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/ChallengeResponeseDTO.java
@@ -20,4 +20,14 @@ public class ChallengeResponeseDTO {
         Boolean isCompleted;
         LocalDateTime createdAt;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SuccessChallengeResultDTO {
+        Long challengId;
+        Boolean isCompleted;
+        LocalDateTime updatedAt;
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/ChallengeResponeseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/ChallengeResponeseDTO.java
@@ -26,7 +26,7 @@ public class ChallengeResponeseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SuccessChallengeResultDTO {
-        Long challengId;
+        Long challengeId;
         Boolean isCompleted;
         LocalDateTime updatedAt;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #108 

## 📝작업 내용
> 챌린지 성공 api 구현

## 🔎코드 설명
> 챌린지 성공 api 구현
> ![image](https://github.com/user-attachments/assets/f6ebbc64-8543-4fdf-a7dd-a218087332c7)
> db에서 id가 18인 데이터의 isCompleted컬럼이 1(true)로 변경됨.
> ![image](https://github.com/user-attachments/assets/b3feada5-0fc7-4a3a-a2f9-b57c0a21ac10)

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
