### PR TITLE
[Feat] 가장 최근에 실패한 5개의 챌린지 조회 api 구현

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/ChallengeConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/ChallengeConverter.java
@@ -4,6 +4,11 @@ import TtattaBackend.ttatta.domain.Challenges;
 import TtattaBackend.ttatta.web.dto.ChallengeRequestDTO;
 import TtattaBackend.ttatta.web.dto.ChallengeResponeseDTO;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class ChallengeConverter {
 
     public static Challenges toChallenge(ChallengeRequestDTO.CreateChallengeRequestDTO request) {
@@ -21,6 +26,24 @@ public class ChallengeConverter {
                 .content(challenge.getContent())
                 .isCompleted(challenge.getIsCompleted())
                 .createdAt(challenge.getCreatedAt())
+                .build();
+    }
+
+    public static ChallengeResponeseDTO.FailChallengeResultDTO toFailChallengeResultDTO(Challenges challenge, int term) {
+        return ChallengeResponeseDTO.FailChallengeResultDTO.builder()
+                .challengeId(challenge.getId())
+                .title(challenge.getTitle())
+                .content(challenge.getContent())
+                .term(term)
+                .build();
+    }
+
+    public static ChallengeResponeseDTO.FailChallengeListResultDTO toFailChallengeListResultDTO(List<Challenges> challengeList) {
+        List<ChallengeResponeseDTO.FailChallengeResultDTO> challengeListDTO = challengeList.stream()
+                .map(challenge -> ChallengeConverter.toFailChallengeResultDTO(challenge, (int) ChronoUnit.DAYS.between(challenge.getCreatedAt(), LocalDateTime.now()))).collect(Collectors.toList());
+
+        return ChallengeResponeseDTO.FailChallengeListResultDTO.builder()
+                .failChallengeList(challengeListDTO)
                 .build();
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/ChallengeRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/ChallengeRepository.java
@@ -1,15 +1,16 @@
 package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.Challenges;
+import TtattaBackend.ttatta.domain.Users;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface ChallengeRepository extends JpaRepository<Challenges, Long> {
-
     @Query("SELECT COUNT(d) FROM Challenges d WHERE DATE(d.createdAt) = DATE(:targetDate)")
     int countByCreatedAtOn(@Param("targetDate") LocalDateTime targetDate);
-
+    List<Challenges> findTop5ByUsersAndIsCompletedFalseOrderByCreatedAtDesc(Users user);
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/ChallengeRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/ChallengeRepository.java
@@ -6,6 +6,7 @@ import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.awt.print.Pageable;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -13,4 +14,11 @@ public interface ChallengeRepository extends JpaRepository<Challenges, Long> {
     @Query("SELECT COUNT(d) FROM Challenges d WHERE DATE(d.createdAt) = DATE(:targetDate)")
     int countByCreatedAtOn(@Param("targetDate") LocalDateTime targetDate);
     List<Challenges> findTop5ByUsersAndIsCompletedFalseOrderByCreatedAtDesc(Users user);
+    @Query("SELECT c FROM Challenges c " +
+            "WHERE c.users = :user " +
+            "AND c.isCompleted = false " +
+            "AND DATE(c.createdAt) <> CURRENT_DATE " +
+            "ORDER BY c.createdAt DESC " +
+            "LIMIT 5")
+    List<Challenges> findTop5ByUserAndIsCompletedFalseExcludeTodayOrderByCreatedAtDesc(@Param("user") Users user);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/ChallengeService/ChallengeQueryService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/ChallengeService/ChallengeQueryService.java
@@ -1,4 +1,9 @@
 package TtattaBackend.ttatta.service.ChallengeService;
 
+import TtattaBackend.ttatta.domain.Challenges;
+
+import java.util.List;
+
 public interface ChallengeQueryService {
+    List<Challenges> getFailChallenges();
 }

--- a/src/main/java/TtattaBackend/ttatta/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -8,6 +8,7 @@ import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.repository.ChallengeRepository;
 import TtattaBackend.ttatta.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -23,6 +24,6 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
     public List<Challenges> getFailChallenges() {
         Long userId = SecurityUtil.getCurrentUserId();
         Users getUser = userRepository.findById(userId).orElseThrow(() -> new ExceptionHandler(ErrorStatus.USER_NOT_FOUND));
-        return challengeRepository.findTop5ByUsersAndIsCompletedFalseOrderByCreatedAtDesc(getUser);
+        return challengeRepository.findTop5ByUserAndIsCompletedFalseExcludeTodayOrderByCreatedAtDesc(getUser);
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -1,9 +1,28 @@
 package TtattaBackend.ttatta.service.ChallengeService;
 
+import TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus;
+import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
+import TtattaBackend.ttatta.config.security.SecurityUtil;
+import TtattaBackend.ttatta.domain.Challenges;
+import TtattaBackend.ttatta.domain.Users;
+import TtattaBackend.ttatta.repository.ChallengeRepository;
+import TtattaBackend.ttatta.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ChallengeQueryServiceImpl implements ChallengeQueryService {
+
+    private final ChallengeRepository challengeRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public List<Challenges> getFailChallenges() {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Users getUser = userRepository.findById(userId).orElseThrow(() -> new ExceptionHandler(ErrorStatus.USER_NOT_FOUND));
+        return challengeRepository.findTop5ByUsersAndIsCompletedFalseOrderByCreatedAtDesc(getUser);
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/ChallengeController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/ChallengeController.java
@@ -6,6 +6,7 @@ import TtattaBackend.ttatta.converter.ItemConverter;
 import TtattaBackend.ttatta.domain.Challenges;
 import TtattaBackend.ttatta.domain.Items;
 import TtattaBackend.ttatta.service.ChallengeService.ChallengeCommandService;
+import TtattaBackend.ttatta.service.ChallengeService.ChallengeQueryService;
 import TtattaBackend.ttatta.service.ItemService.ItemCommandService;
 import TtattaBackend.ttatta.web.dto.ChallengeRequestDTO;
 import TtattaBackend.ttatta.web.dto.ChallengeResponeseDTO;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class ChallengeController {
 
     private final ChallengeCommandService challengeCommandService;
+    private final ChallengeQueryService challengeQueryService;
 
     @Operation(summary = "챌린지 생성 api",
             description = "챌린지를 생성하는 api입니다.\n"
@@ -36,17 +38,14 @@ public class ChallengeController {
         );
     }
 
-//    @Operation(summary = "아이템 구매 api",
-//            description = "아이템을 구매하는 api입니다.\npath path variable 로 구매하려는 아이템 id를 받습니다.")
-//    @PatchMapping("/{itemId}")
-//    public ApiResponse<ItemResponseDTO.ItemBuyResultDTO> buy (@PathVariable Long itemId) {
-//        return ApiResponse.onSuccess(itemCommandService.buyItem(itemId));
-//    }
-//
-//    @Operation(summary = "아이템 착용 api",
-//            description = "아이템을 착용하는 api 입니다.\n path variable로 착용하려는 아이템 id를 받습니다.")
-//    @PatchMapping("/equip/{itemId}")
-//    public ApiResponse<ItemResponseDTO.ItemEquipResultDTO> equip (@PathVariable Long itemId) {
-//        return ApiResponse.onSuccess(itemCommandService.equipItem(itemId));
-//    }
+    @Operation(summary = "가장 최근dp 실패한 챌린지 5개 조회 api",
+            description = "가장 최근에 실패한 5개의 챌린지를 조회하는 api입니다.\n"
+                    + "header에 access token을 넣어주세요.")
+    @GetMapping("/fail")
+    public ApiResponse<ChallengeResponeseDTO.FailChallengeListResultDTO> getFailChallenges() {
+        return ApiResponse.onSuccess(
+                ChallengeConverter.toFailChallengeListResultDTO(challengeQueryService.getFailChallenges())
+        );
+    }
+
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/ChallengeController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/ChallengeController.java
@@ -38,7 +38,7 @@ public class ChallengeController {
         );
     }
 
-    @Operation(summary = "가장 최근dp 실패한 챌린지 5개 조회 api",
+    @Operation(summary = "가장 최근에 실패한 챌린지 5개 조회 api",
             description = "가장 최근에 실패한 5개의 챌린지를 조회하는 api입니다.\n"
                     + "header에 access token을 넣어주세요.")
     @GetMapping("/fail")

--- a/src/main/java/TtattaBackend/ttatta/web/dto/ChallengeResponeseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/ChallengeResponeseDTO.java
@@ -37,6 +37,6 @@ public class ChallengeResponeseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class FailChallengeListResultDTO {
-        List<ChallengeResponeseDTO.FailChallengeResultDTO> failChallengeList;
+        List<FailChallengeResultDTO> failChallengeList;
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/ChallengeResponeseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/ChallengeResponeseDTO.java
@@ -1,12 +1,12 @@
 package TtattaBackend.ttatta.web.dto;
 
-import TtattaBackend.ttatta.domain.enums.LoginType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ChallengeResponeseDTO {
     @Getter
@@ -19,5 +19,24 @@ public class ChallengeResponeseDTO {
         String content;
         Boolean isCompleted;
         LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FailChallengeResultDTO {
+        Long challengeId;
+        String title;
+        String content;
+        int term;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FailChallengeListResultDTO {
+        List<ChallengeResponeseDTO.FailChallengeResultDTO> failChallengeList;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #110 

## 📝작업 내용
> 가장 최근에 실패한 5개의 챌린지 조회 api 구현

## 🔎코드 설명
> 가장 최근에 실패한 5개의 챌린지 조회 api 구현
> ![image](https://github.com/user-attachments/assets/4e3e3cd6-fb6d-49f3-8b18-f6ac3cffd4a1)

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x