### PR TITLE
[Feat] response body에 일기 카테고리 id 필드 추가

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
@@ -71,6 +71,7 @@ public class DiaryConverter {
 
         return DiaryResponseDTO.KeepDiaryDTO.builder()
                 .diaryId(diaries.getId())
+                .diaryCategoryId(diaries.getDiaryCategories().getId())
                 .date(diaries.getDate())
                 .content(diaries.getContent())
                 .image(imageUrl)
@@ -111,6 +112,7 @@ public class DiaryConverter {
 
         return DiaryResponseDTO.SearchDiaryDTO.builder()
                 .diaryId(diaries.getId())
+                .diaryCategoryId(diaries.getDiaryCategories().getId())
                 .content(diaries.getContent())
                 .date(diaries.getDate())
                 .image(imageUrl)

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
@@ -63,6 +63,7 @@ public class DiaryResponseDTO {
     @AllArgsConstructor
     public static class KeepDiaryDTO {
         Long diaryId;
+        Long diaryCategoryId;
         LocalDateTime date;
         String content;
         String image;
@@ -97,6 +98,7 @@ public class DiaryResponseDTO {
     @AllArgsConstructor
     public static class SearchDiaryDTO {
         Long diaryId;
+        Long diaryCategoryId;
         LocalDateTime date;
         String content;
         String image;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #116 

## 📝작업 내용
> 일기 보관함, 일기 검색 조회에 카테고리 id 추가 반환

## 🔎코드 설명
> response body: diaryCategoryId 추가
> Converter: diaries.getCategories.getId로 id 불러옴

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> 프론트 요청으로 수정한 코드입니다.
<img width="612" alt="스크린샷 2025-02-11 오후 10 13 11" src="https://github.com/user-attachments/assets/409084bc-f798-45f9-9d6b-6fefe92987c0" />

## Swagger
> 일기 보관함
<img width="199" alt="스크린샷 2025-02-11 오후 10 13 53" src="https://github.com/user-attachments/assets/90c4def7-6891-4bb9-a0f6-e454f9780202" />

> 일기 검색 조회
<img width="190" alt="스크린샷 2025-02-11 오후 10 14 23" src="https://github.com/user-attachments/assets/f8a1c2df-0dc2-4e03-be6d-c8b9595279eb" />
