### PR TITLE
[Feat] 카카오 회원가입 API

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -3,7 +3,6 @@ package TtattaBackend.ttatta.converter;
 import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.domain.enums.IsAvailable;
 import TtattaBackend.ttatta.domain.enums.LoginType;
-import TtattaBackend.ttatta.oidc.OauthInfo;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserResponseDTO;
 
@@ -21,11 +20,33 @@ public class UserConverter {
                 .build();
     }
 
+    public static Users toKakaoUsers(UserRequestDTO.SignUpKakaoRequestDTO request, String sub) {
+        return Users.builder()
+                .name(null)
+                .email(null)
+                .password(null)
+                .username(null)
+                .diaryCategoriesList(new ArrayList<>())
+                .providerId(sub)
+                .nickname(request.getNickname())
+                .loginType(LoginType.KAKAO)
+                .build();
+    }
+
     public static UserResponseDTO.UserSignUpResultDTO toUserSignUpResultDTO(Users users) {
         return UserResponseDTO.UserSignUpResultDTO.builder()
                 .userId(users.getId())
                 .nickname(users.getNickname())
                 .loginType(users.getLoginType())
+                .createdAt(users.getCreatedAt())
+                .build();
+    }
+
+    public static UserResponseDTO.UserKaKaoSignUpResultDTO toUserKaKaoSignUpResultDTO(Users users) {
+        return UserResponseDTO.UserKaKaoSignUpResultDTO.builder()
+                .nickname(users.getNickname())
+                .loginType(users.getLoginType())
+                .userId(users.getId())
                 .createdAt(users.getCreatedAt())
                 .build();
     }

--- a/src/main/java/TtattaBackend/ttatta/domain/Users.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Users.java
@@ -28,23 +28,23 @@ public class Users extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column
     private String name;
 
     @Column(nullable = false, length = 8)
     private String nickname;
 
-    @Column(nullable = false, length = 15)
+    @Column(length = 15)
     private String username;
 
-    @Column(nullable = false, length = 100)
+    @Column(length = 100)
     private String password;
 
     @Enumerated(EnumType.STRING)
     @Column
     private LoginType loginType;
 
-    @Column(nullable = false, length = 50)
+    @Column(length = 50)
     private String email;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -12,8 +12,8 @@ public interface UserCommandService {
     void logout(String accessToken);
     UserResponseDTO.UserSignInResultDTO signIn(UserRequestDTO.SignInRequestDTO request);
     UserResponseDTO.RefreshResultDTO refresh(String refreshToken);
-    Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request);    // 미구현
-    Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
+    Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request);
+//    Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
     UserResponseDTO.UserInfoResultDTO getUserInfo();
     Users editUserInfo(UserRequestDTO.EditRequestDTO request);
     void deleteUser();

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -86,6 +87,24 @@ public class UserCommandServiceImpl implements UserCommandService {
     public Users signUp(UserRequestDTO.SignUpRequestDTO request) {
         Users newUser = UserConverter.toUsers(request);
         newUser.encodePassword(passwordEncoder.encode(request.getPassword()));
+        // 일상 카테고리 생성
+        createDefaultCategory(newUser);
+        return userRepository.save(newUser);
+    }
+
+    @Override
+    @Transactional
+    public Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request) {
+
+        // openId를 통해 sub 추출하기
+        OIDCPublicKeyResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
+        OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(request.getOpenId(), iss, aud, oidcPublicKeysResponse);
+        String sub = oidcDecodePayload.getSub();
+
+        String accessToken = "";
+        String refreshToken = "";
+
+        Users newUser = UserConverter.toKakaoUsers(request, sub);
         // 일상 카테고리 생성
         createDefaultCategory(newUser);
         return userRepository.save(newUser);
@@ -180,18 +199,11 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     // 미구현
-    @Override
-    public Users signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request) {
-        // 서비스 구현
-        return null;
-    }
-
-    // 미구현
-    @Override
-    public Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request) {
-        // 서비스 구현
-        return null;
-    }
+//    @Override
+//    public Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request) {
+//        // 서비스 구현
+//        return null;
+//    }
 
     @Override
     public UserResponseDTO.UserInfoResultDTO getUserInfo() {

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -17,9 +17,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/users")
 public class UserController {
     private final UserCommandService userCommandService;
-    private final KakaoOauthClient kakaoOauthClient;
-    private final JwtOIDCProvider jwtOIDCProvider;
-    private final OauthOIDCHelper oauthOIDCHelper;
 
     @Operation(summary = "(개발용) 테스트 유저 생성", description =
             "# Test User를 생성합니다. 다른 기능을 테스트 할때 이용 하세요."
@@ -105,32 +102,33 @@ public class UserController {
             "# 카카오 회원가입 API 입니다."
     )
     @PostMapping("/signup/kakao")
-    public ApiResponse<UserResponseDTO.UserSignUpResultDTO> signUpKakao(
+    public ApiResponse<UserResponseDTO.UserKaKaoSignUpResultDTO> signUpKakao(
             @RequestBody UserRequestDTO.SignUpKakaoRequestDTO request
     ) {
         Users newUser = userCommandService.signUpKakao(request);
+
         return ApiResponse.onSuccess(
-                UserConverter.toUserSignUpResultDTO(
+                UserConverter.toUserKaKaoSignUpResultDTO(
                         newUser
                 )
         );
     }
 
     // 미구현
-    @Operation(summary = "카카오 로그인", description =
-            "# 카카오 로그인 API 입니다."
-    )
-    @PostMapping("/signin/kakao")
-    public ApiResponse<UserResponseDTO.UserSignInResultDTO> signInKakao(
-            @RequestBody UserRequestDTO.SignInKakaoRequestDTO request
-    ) {
-        Users user = userCommandService.signInKakao(request);
-        return ApiResponse.onSuccess(
-                UserConverter.toUserSignInResultDTO(
-                        user, null, null
-                )
-        );
-    }
+//    @Operation(summary = "카카오 로그인", description =
+//            "# 카카오 로그인 API 입니다."
+//    )
+//    @PostMapping("/signin/kakao")
+//    public ApiResponse<UserResponseDTO.UserSignInResultDTO> signInKakao(
+//            @RequestBody UserRequestDTO.SignInKakaoRequestDTO request
+//    ) {
+//        Users user = userCommandService.signInKakao(request);
+//        return ApiResponse.onSuccess(
+//                UserConverter.toUserSignInResultDTO(
+//                        user, null, null
+//                )
+//        );
+//    }
 
     @Operation(summary = "회원 정보 조회", description =
             "# 회원 정보 조회 API 입니다."

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -41,24 +41,26 @@ public class UserRequestDTO {
         private String password;
     }
   
-    // 미구현
     @Getter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     public static class SignUpKakaoRequestDTO {
-        private String kakaoToken;
+        private String openId;
+        @NotBlank(message = "닉네임은 빈값일 수 없습니다.")
+        @Size(max = 8, message = "닉네임은 1 ~ 8자이어야 합니다.")
         private String nickname;
     }
       
     // 미구현
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class SignInKakaoRequestDTO {
-        private String kakaoToken;
-    }
+    // 하단의 tokenValidationRequestDTO 에서 카카오 로그인 구현함
+//    @Getter
+//    @Builder
+//    @AllArgsConstructor
+//    @NoArgsConstructor
+//    public static class SignInKakaoRequestDTO {
+//        private String kakaoToken;
+//    }
 
     @Getter
     @Builder

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -128,6 +128,8 @@ public class UserResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UserKaKaoSignUpResultDTO {
+        String accessToken;
+        String refreshToken;
         Long userId;
         String nickname;
         LoginType loginType;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #121 

## 📝작업 내용
> Users 도메인 수정
> 카카오 회원가입을 위한 DTO 수정
> 카카오로 회원가입을 위한 Service 생성
> 컨트롤러 수정
> 회원가입을 위한 컨버터, DTO로 변환하기 위한 컨버터 구현

## 🔎코드 설명
> Users 도메인 : 카카오 로그인 시 필요 없는 값들은 nullable = false 제거
> DTO 수정 : request -> OpenId, nickname 입력, response -> token 추가
> Service : sub, nickname을 사용하여 새 객체 DB에 저장, "일상" 카테고리 생성
> 컨트롤러 : 카카오 회원가입 형에 맞게 return
> 컨버터 : Users로 만드는 컨버터, ResultDTO로 만드는 컨버터

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 회원가입 로직에는 accessToken과 refreshToken이 쓰이지 않아서...일단 만들어놓긴했는데 어디에서 해야할지 잘 모르겠습니다..ㅜㅜ

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
