### PR TITLE
[Feat] 카카오 로그인 Id token 검증 api와 카카오 회원가입 api의 request body에 있는 openId값을 header로 변경

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -12,11 +12,11 @@ public interface UserCommandService {
     void logout(String accessToken);
     UserResponseDTO.UserSignInResultDTO signIn(UserRequestDTO.SignInRequestDTO request);
     UserResponseDTO.RefreshResultDTO refresh(String refreshToken);
-    UserResponseDTO.UserKaKaoSignUpResultDTO signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request);
+    UserResponseDTO.UserKaKaoSignUpResultDTO signUpKakao(String openId, UserRequestDTO.SignUpKakaoRequestDTO request);
 //    Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
     UserResponseDTO.UserInfoResultDTO getUserInfo();
     Users editUserInfo(UserRequestDTO.EditRequestDTO request);
     void deleteUser();
-    UserResponseDTO.TokenValidationResultDTO validateToken(UserRequestDTO.tokenValidationRequestDTO request);
+    UserResponseDTO.TokenValidationResultDTO validateToken(String openId);
     Long getUserPoint();
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -92,11 +92,11 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     @Override
     @Transactional
-    public UserResponseDTO.UserKaKaoSignUpResultDTO signUpKakao(UserRequestDTO.SignUpKakaoRequestDTO request) {
+    public UserResponseDTO.UserKaKaoSignUpResultDTO signUpKakao(String openId, UserRequestDTO.SignUpKakaoRequestDTO request) {
 
         // openId를 통해 sub 추출하기
         OIDCPublicKeyResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
-        OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(request.getOpenId(), iss, aud, oidcPublicKeysResponse);
+        OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(openId, iss, aud, oidcPublicKeysResponse);
         String sub = oidcDecodePayload.getSub();
 
         Users newUser = UserConverter.toKakaoUsers(request, sub);
@@ -222,12 +222,12 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public UserResponseDTO.TokenValidationResultDTO validateToken(UserRequestDTO.tokenValidationRequestDTO request) {
+    public UserResponseDTO.TokenValidationResultDTO validateToken(String openId) {
         // 공개키 가져오기
         OIDCPublicKeyResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
 
         // 페이로드 검증 && 서명 검증 후 sub 값 기준으로 회원가입 or 로그인 처리
-        OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(request.getOpenId(), iss, aud, oidcPublicKeysResponse);
+        OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(openId, iss, aud, oidcPublicKeysResponse);
         String sub = oidcDecodePayload.getSub();
 
         if (sub == null || sub.isEmpty()) {

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -99,14 +99,15 @@ public class UserController {
 
     // 미구현
     @Operation(summary = "카카오 회원가입", description =
-            "# 카카오 회원가입 API 입니다."
+            "# 카카오 회원가입 API 입니다. header에 'OpneId: {ID token}'형식으로 ID token을 입력하고 request body에 닉네임을 입력해주세요."
     )
     @PostMapping("/signup/kakao")
     public ApiResponse<UserResponseDTO.UserKaKaoSignUpResultDTO> signUpKakao(
+            @RequestHeader("OpneId") String openId,
             @RequestBody UserRequestDTO.SignUpKakaoRequestDTO request
     ) {
         return ApiResponse.onSuccess(
-                userCommandService.signUpKakao(request)
+                userCommandService.signUpKakao(openId, request)
         );
     }
 
@@ -199,18 +200,18 @@ public class UserController {
         );
     }
 
-    @Operation(summary = "카카오 로그인 시 토큰 검정하는 API", description =
-            "카카오로 계속할 때 회원가입인지 로그인인지 확인하는 API. " +
-                    "1. 페이로드 검증 및 서명 검증을 진행합니다."+
-                    "2. 이미 가입한 회원인지 확인합니다."+
-                    "ID token을 입력해주세요."
+    @Operation(summary = "카카오 로그인 시 회원가입인지 로그인인지 확인하는 API", description =
+                    "header에 'OpneId: {ID token}'형식으로 ID token을 입력해주세요.\n" +
+                    "1. 페이로드 검증 및 서명 검증을 진행합니다.\n" +
+                    "2. 이미 가입한 회원인지 확인합니다.\n\n" +
+                    "회원가입이라면 isRegistered로 false를 반환하고 로그인이라면 isRegistered로 true를 반환함과 동시에 access token과 refresh token을 반환합니다."
     )
     @PostMapping("/verificate/kakao")
     public ApiResponse<UserResponseDTO.TokenValidationResultDTO> validKakaoToken(
-            @RequestBody @Valid UserRequestDTO.tokenValidationRequestDTO request
+            @RequestHeader("OpneId") String openId
     ) {
         return ApiResponse.onSuccess(
-                userCommandService.validateToken(request)
+                userCommandService.validateToken(openId)
         );
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -46,7 +46,6 @@ public class UserRequestDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class SignUpKakaoRequestDTO {
-        private String openId;
         @NotBlank(message = "닉네임은 빈값일 수 없습니다.")
         @Size(max = 8, message = "닉네임은 1 ~ 8자이어야 합니다.")
         private String nickname;
@@ -61,14 +60,6 @@ public class UserRequestDTO {
 //    public static class SignInKakaoRequestDTO {
 //        private String kakaoToken;
 //    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class tokenValidationRequestDTO {
-        private String openId;
-    }
 
     @Getter
     @Builder


### PR DESCRIPTION
## #️⃣연관된 이슈
> #125

## 📝작업 내용
> 카카오 로그인 Id token 검증 api와 카카오 회원가입 api의 request body에 있는 openId값을 header로 변경

## 🔎코드 설명
> controller에서 카카오 로그인 Id token 검증 api와 카카오 회원가입 api요청 시 request body에 있는 openId값을 header로 변경

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
