### PR TITLE
[Feat] 이메일 인증 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// gmail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -23,6 +23,9 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "USER_1004", "이미 존재하는 이메일 입니다."),
     CODE_NOT_EQUAL(HttpStatus.BAD_REQUEST, "USER_1005", "인증코드가 일치하지 않습니다."),
     NAME_NOT_EQUAL(HttpStatus.BAD_REQUEST, "USER_1006", "이름이 일치하지 않습니다."),
+    ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_1007", "해당하는 ID가 존재하지 않습니다."),
+    ID_NOT_EQUAL(HttpStatus.BAD_REQUEST, "USER_1008", "ID가 일치하지 않습니다."),
+    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "USER_1009", "이전 비밀번호와 동일합니다."),
 
     // 일기 관련 응답 2000
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_2001", "해당하는 일기가 존재하지 않습니다."),

--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -22,6 +22,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER_1003", "닉네임은 필수 입니다."),
     EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "USER_1004", "이미 존재하는 이메일 입니다."),
     CODE_NOT_EQUAL(HttpStatus.BAD_REQUEST, "USER_1005", "인증코드가 일치하지 않습니다."),
+    NAME_NOT_EQUAL(HttpStatus.BAD_REQUEST, "USER_1006", "이름이 일치하지 않습니다."),
 
     // 일기 관련 응답 2000
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_2001", "해당하는 일기가 존재하지 않습니다."),

--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -20,6 +20,8 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_ID_NULL(HttpStatus.BAD_REQUEST, "USER_1001", "사용자 아이디는 필수 입니다."),
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_1002", "해당하는 사용자가 존재하지 않습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER1003", "닉네임은 필수 입니다."),
+    NAME_NOT_EQUAL(HttpStatus.BAD_REQUEST, "USER1004", "이름이 일치하지 않습니다."),
+    EMAIL_NOT_EQUAL(HttpStatus.BAD_REQUEST, "USER1005", "이메일이 일치하지 않습니다."),
 
     // 일기 관련 응답 2000
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_2001", "해당하는 일기가 존재하지 않습니다."),

--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -19,9 +19,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 회원 관련 응답 1000
     USER_ID_NULL(HttpStatus.BAD_REQUEST, "USER_1001", "사용자 아이디는 필수 입니다."),
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_1002", "해당하는 사용자가 존재하지 않습니다."),
-    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER1003", "닉네임은 필수 입니다."),
-    NAME_NOT_EQUAL(HttpStatus.BAD_REQUEST, "USER1004", "이름이 일치하지 않습니다."),
-    EMAIL_NOT_EQUAL(HttpStatus.BAD_REQUEST, "USER1005", "이메일이 일치하지 않습니다."),
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER_1003", "닉네임은 필수 입니다."),
+    EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "USER_1004", "이미 존재하는 이메일 입니다."),
+    CODE_NOT_EQUAL(HttpStatus.BAD_REQUEST, "USER_1005", "인증코드가 일치하지 않습니다."),
 
     // 일기 관련 응답 2000
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_2001", "해당하는 일기가 존재하지 않습니다."),

--- a/src/main/java/TtattaBackend/ttatta/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/TtattaBackend/ttatta/config/security/JwtAuthenticationFilter.java
@@ -36,6 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/users/signin",
             "/users/signin/**",
             "/users/testuser",
+            "/users/find/**",
             "/swagger-ui/**",
             "/v3/**"
 //            "/refresh", "/",

--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -65,4 +65,11 @@ public class UserConverter {
                 .status(users.getStatus())
                 .build();
     }
+
+    public static UserResponseDTO.FindIdResultDTO toFindIdResultDTO(Users users) {
+        return UserResponseDTO.FindIdResultDTO.builder()
+                .id(users.getUsername())
+                .name(users.getName())
+                .build();
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -65,10 +65,4 @@ public class UserConverter {
                 .status(users.getStatus())
                 .build();
     }
-
-    public static UserResponseDTO.SendVerificationMailResultDTO toSendVerificationMailResultDTO(Integer verificationCode) {
-        return UserResponseDTO.SendVerificationMailResultDTO.builder()
-                .verificationCode(verificationCode)
-                .build();
-    }
 }

--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -65,4 +65,10 @@ public class UserConverter {
                 .status(users.getStatus())
                 .build();
     }
+
+    public static UserResponseDTO.SendVerificationMailResultDTO toSendVerificationMailResultDTO(Integer verificationCode) {
+        return UserResponseDTO.SendVerificationMailResultDTO.builder()
+                .verificationCode(verificationCode)
+                .build();
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/UserRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/UserRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByUsername(String username);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/UserRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/UserRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByUsername(String username);
     boolean existsByEmail(String email);
+    Optional<Users> findByEmail(String email);
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/UserRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByUsername(String username);
     boolean existsByEmail(String email);
     Optional<Users> findByEmail(String email);
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -19,6 +19,6 @@ public interface UserCommandService {
     void sendMail(String email);
     void sendVerificationMailSignUp(UserRequestDTO.SendVerificationMailSignUpRequestDTO request);
     void checkVerificationCode(UserRequestDTO.CheckVerificationCodeRequestDTO request);
-    void sendVerificationMailFind(UserRequestDTO.SendVerificationMailFindRequestDTO request);
+    void sendVerificationMailFindId(UserRequestDTO.SendVerificationMailFindIdRequestDTO request);
     UserResponseDTO.FindIdResultDTO findId(UserRequestDTO.CheckVerificationCodeRequestDTO request);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -16,4 +16,5 @@ public interface UserCommandService {
     Users getUserInfo();
     Users updateUserInfo(UserRequestDTO.UpdateRequestDTO request);
     void deleteUser();
+    void sendVerificationMail();
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -21,4 +21,6 @@ public interface UserCommandService {
     void checkVerificationCode(UserRequestDTO.CheckVerificationCodeRequestDTO request);
     void sendVerificationMailFindId(UserRequestDTO.SendVerificationMailFindIdRequestDTO request);
     UserResponseDTO.FindIdResultDTO findId(UserRequestDTO.CheckVerificationCodeRequestDTO request);
+    void sendVerificationMailFindPw(UserRequestDTO.SendVerificationMailFindPwRequestDTO request);
+    void findPw(UserRequestDTO.FindPwRequestDTO request);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -22,6 +22,7 @@ public interface UserCommandService {
     void checkVerificationCode(UserRequestDTO.CheckVerificationCodeRequestDTO request);
     void sendVerificationMailFindId(UserRequestDTO.SendVerificationMailFindIdRequestDTO request);
     UserResponseDTO.FindIdResultDTO findId(UserRequestDTO.CheckVerificationCodeRequestDTO request);
+    void verifyUsername(String username);
     void sendVerificationMailFindPw(UserRequestDTO.SendVerificationMailFindPwRequestDTO request);
     void findPw(UserRequestDTO.FindPwRequestDTO request);
     UserResponseDTO.TokenValidationResultDTO validateToken(String openId);

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -16,5 +16,6 @@ public interface UserCommandService {
     Users getUserInfo();
     Users updateUserInfo(UserRequestDTO.UpdateRequestDTO request);
     void deleteUser();
-    Integer sendVerificationMail(UserRequestDTO.SendVerificationMailRequestDTO request);
+    void sendVerificationMailSignUp(UserRequestDTO.SendVerificationMailSignUpRequestDTO request);
+    void checkVerificationCodeSignUp(UserRequestDTO.CheckVerificationCodeSignUpRequestDTO request);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -16,6 +16,9 @@ public interface UserCommandService {
     Users getUserInfo();
     Users updateUserInfo(UserRequestDTO.UpdateRequestDTO request);
     void deleteUser();
+    void sendMail(String email);
     void sendVerificationMailSignUp(UserRequestDTO.SendVerificationMailSignUpRequestDTO request);
-    void checkVerificationCodeSignUp(UserRequestDTO.CheckVerificationCodeSignUpRequestDTO request);
+    void checkVerificationCode(UserRequestDTO.CheckVerificationCodeRequestDTO request);
+    void sendVerificationMailFind(UserRequestDTO.SendVerificationMailFindRequestDTO request);
+    UserResponseDTO.FindIdResultDTO findId(UserRequestDTO.CheckVerificationCodeRequestDTO request);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -16,5 +16,5 @@ public interface UserCommandService {
     Users getUserInfo();
     Users updateUserInfo(UserRequestDTO.UpdateRequestDTO request);
     void deleteUser();
-    void sendVerificationMail();
+    Integer sendVerificationMail(UserRequestDTO.SendVerificationMailRequestDTO request);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -344,6 +344,7 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         // 새 비밀번호 암호화 후 업데이트
         user.encodePassword(passwordEncoder.encode(request.getPassword()));
+    }
 
     public UserResponseDTO.TokenValidationResultDTO validateToken(String openId) {
         // 공개키 가져오기

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -192,13 +192,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public void sendVerificationMailSignUp(UserRequestDTO.SendVerificationMailSignUpRequestDTO request) {
-        String inputEmail = request.getEmail();
-
-        // 이메일 중복 여부 확인
-        if(userRepository.existsByEmail(inputEmail)) {
-            throw new ExceptionHandler(EMAIL_ALREADY_EXIST);
-        }
+    public void sendMail(String email) {
 
         // 인증 번호 (6자리 난수) 생성
         int verificationCode = (int)(Math.random() * 899999) + 100000;
@@ -207,8 +201,8 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         // 이메일 내용 설정
         try {
-            message.setFrom(inputEmail);
-            message.setRecipients(MimeMessage.RecipientType.TO, inputEmail);
+            message.setFrom(email);
+            message.setRecipients(MimeMessage.RecipientType.TO, email);
             message.setSubject("[따따] 이메일 인증 코드 발송");
             String body = "";
             body += "<h3>" + "요청하신 인증 번호입니다." + "</h3>";
@@ -220,13 +214,25 @@ public class UserCommandServiceImpl implements UserCommandService {
         }
 
         // 인증번호 Redis 저장 (유효시간 10분)
-        redisTemplate.opsForValue().set(inputEmail, String.valueOf(verificationCode), 10, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set(email, String.valueOf(verificationCode), 10, TimeUnit.MINUTES);
 
         javaMailSender.send(message);
     }
 
     @Override
-    public void checkVerificationCodeSignUp(UserRequestDTO.CheckVerificationCodeSignUpRequestDTO request) {
+    public void sendVerificationMailSignUp(UserRequestDTO.SendVerificationMailSignUpRequestDTO request) {
+        String inputEmail = request.getEmail();
+
+        // 이메일 중복 여부 확인
+        if(userRepository.existsByEmail(inputEmail)) {
+            throw new ExceptionHandler(EMAIL_ALREADY_EXIST);
+        }
+
+        sendMail(inputEmail);
+    }
+
+    @Override
+    public void checkVerificationCode(UserRequestDTO.CheckVerificationCodeRequestDTO request) {
         String inputEmail = request.getEmail();
         String inputCode = request.getCode();
 
@@ -237,5 +243,33 @@ public class UserCommandServiceImpl implements UserCommandService {
         if (code == null || !code.equals(inputCode)) {
             throw new ExceptionHandler(CODE_NOT_EQUAL);
         }
+    }
+
+    @Override
+    public void sendVerificationMailFind(UserRequestDTO.SendVerificationMailFindRequestDTO request) {
+        String inputName = request.getName();
+        String inputEmail = request.getEmail();
+
+        // 이메일로 유저 찾기
+        Users user = userRepository.findByEmail(inputEmail)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        // 이메일와 이름 일치 여부 확인
+        if(!user.getName().equals(inputName)) {
+            throw new ExceptionHandler(NAME_NOT_EQUAL);
+        }
+
+        sendMail(inputEmail);
+    }
+
+    @Override
+    public UserResponseDTO.FindIdResultDTO findId(UserRequestDTO.CheckVerificationCodeRequestDTO request) {
+        checkVerificationCode(request);
+
+        // 이메일로 유저 찾기
+        Users user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        return UserConverter.toFindIdResultDTO(user);
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -11,18 +11,18 @@ import TtattaBackend.ttatta.jwt.JwtUtils;
 import TtattaBackend.ttatta.repository.DiaryCategoryRepository;
 import TtattaBackend.ttatta.repository.UserRepository;
 import TtattaBackend.ttatta.web.dto.DiaryCategoryRequestDTO;
-import TtattaBackend.ttatta.web.dto.DiaryCategoryResponseDTO;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserResponseDTO;
+import jakarta.mail.internet.MimeMessage;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -48,6 +48,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtUtils jwtUtils;
     private final RedisTemplate<String, String> redisTemplate;
+    private final JavaMailSender javaMailSender;
 
     @Override
     public Users createTestUser() {
@@ -188,5 +189,31 @@ public class UserCommandServiceImpl implements UserCommandService {
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
 
         userRepository.delete(user);
+    }
+
+    @Override
+    public void sendVerificationMail() {
+        Users user = userRepository.findById(SecurityUtil.getCurrentUserId())
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        // 인증 번호 (6자리 난수) 생성
+        int verificationCode = (int)(Math.random() * 899999) + 100000;
+
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        try {
+            message.setFrom(user.getEmail());
+            message.setRecipients(MimeMessage.RecipientType.TO, user.getEmail());
+            message.setSubject("[따따] 이메일 인증 코드 발송");
+            String body = "";
+            body += "<h3>" + "요청하신 인증 번호입니다." + "</h3>";
+            body += "<h1>" + verificationCode + "</h1>";
+            body += "<h3>" + "감사합니다." + "</h3>";
+            message.setText(body, "utf-8", "html");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        javaMailSender.send(message);
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -272,4 +272,44 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         return UserConverter.toFindIdResultDTO(user);
     }
+
+    @Override
+    public void sendVerificationMailFindPw(UserRequestDTO.SendVerificationMailFindPwRequestDTO request) {
+        String inputId = request.getUsername();
+        String inputName = request.getName();
+        String inputEmail = request.getEmail();
+
+        // 아이디 존재 여부 확인
+        if(!userRepository.existsByUsername(inputId)) {
+            throw new ExceptionHandler(ID_NOT_FOUND);
+        }
+
+        // 이메일로 유저 찾기
+        Users user = userRepository.findByEmail(inputEmail)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        // 이메일와 이름, 아이디 일치 여부 확인
+        if(!user.getName().equals(inputName)) {
+            throw new ExceptionHandler(NAME_NOT_EQUAL);
+        }
+        else if(!user.getUsername().equals(inputId)) {
+            throw new ExceptionHandler(ID_NOT_EQUAL);
+        }
+
+        sendMail(inputEmail);
+    }
+
+    @Override
+    public void findPw(UserRequestDTO.FindPwRequestDTO request) {
+        Users user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        // 입력된 새 비밀번호가 기존 비밀번호와 동일한지 확인
+        if (passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new ExceptionHandler(SAME_PASSWORD);
+        }
+
+        // 새 비밀번호 암호화 후 업데이트
+        user.encodePassword(passwordEncoder.encode(request.getPassword()));
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -192,15 +192,12 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public Integer sendVerificationMail(UserRequestDTO.SendVerificationMailRequestDTO request) {
-        Users user = userRepository.findById(SecurityUtil.getCurrentUserId())
-                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+    public void sendVerificationMailSignUp(UserRequestDTO.SendVerificationMailSignUpRequestDTO request) {
+        String inputEmail = request.getEmail();
 
-        // 이름, 이메일 일치 검증
-        if(!user.getName().equals(request.getName())) {
-            throw new ExceptionHandler(NAME_NOT_EQUAL);
-        } else if(!user.getEmail().equals(request.getEmail())) {
-            throw new ExceptionHandler(EMAIL_NOT_EQUAL);
+        // 이메일 중복 여부 확인
+        if(userRepository.existsByEmail(inputEmail)) {
+            throw new ExceptionHandler(EMAIL_ALREADY_EXIST);
         }
 
         // 인증 번호 (6자리 난수) 생성
@@ -210,8 +207,8 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         // 이메일 내용 설정
         try {
-            message.setFrom(user.getEmail());
-            message.setRecipients(MimeMessage.RecipientType.TO, user.getEmail());
+            message.setFrom(inputEmail);
+            message.setRecipients(MimeMessage.RecipientType.TO, inputEmail);
             message.setSubject("[따따] 이메일 인증 코드 발송");
             String body = "";
             body += "<h3>" + "요청하신 인증 번호입니다." + "</h3>";
@@ -222,8 +219,23 @@ public class UserCommandServiceImpl implements UserCommandService {
             e.printStackTrace();
         }
 
-        javaMailSender.send(message);
+        // 인증번호 Redis 저장 (유효시간 10분)
+        redisTemplate.opsForValue().set(inputEmail, String.valueOf(verificationCode), 10, TimeUnit.MINUTES);
 
-        return verificationCode;
+        javaMailSender.send(message);
+    }
+
+    @Override
+    public void checkVerificationCodeSignUp(UserRequestDTO.CheckVerificationCodeSignUpRequestDTO request) {
+        String inputEmail = request.getEmail();
+        String inputCode = request.getCode();
+
+        // 입력한 이메일로 저장된 인증번호 가져오기
+        String code = redisTemplate.opsForValue().get(inputEmail);
+
+        // 인증번호 일치 여부 확인
+        if (code == null || !code.equals(inputCode)) {
+            throw new ExceptionHandler(CODE_NOT_EQUAL);
+        }
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -246,7 +246,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public void sendVerificationMailFind(UserRequestDTO.SendVerificationMailFindRequestDTO request) {
+    public void sendVerificationMailFindId(UserRequestDTO.SendVerificationMailFindIdRequestDTO request) {
         String inputName = request.getName();
         String inputEmail = request.getEmail();
 

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -307,6 +307,14 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
+    public void verifyUsername(String username) {
+        // 아이디 존재 여부 확인
+        if(!userRepository.existsByUsername(username)) {
+            throw new ExceptionHandler(ID_NOT_FOUND);
+        }
+    }
+
+    @Override
     public void sendVerificationMailFindPw(UserRequestDTO.SendVerificationMailFindPwRequestDTO request) {
         String inputId = request.getUsername();
         String inputName = request.getName();

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -192,15 +192,23 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public void sendVerificationMail() {
+    public Integer sendVerificationMail(UserRequestDTO.SendVerificationMailRequestDTO request) {
         Users user = userRepository.findById(SecurityUtil.getCurrentUserId())
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        // 이름, 이메일 일치 검증
+        if(!user.getName().equals(request.getName())) {
+            throw new ExceptionHandler(NAME_NOT_EQUAL);
+        } else if(!user.getEmail().equals(request.getEmail())) {
+            throw new ExceptionHandler(EMAIL_NOT_EQUAL);
+        }
 
         // 인증 번호 (6자리 난수) 생성
         int verificationCode = (int)(Math.random() * 899999) + 100000;
 
         MimeMessage message = javaMailSender.createMimeMessage();
 
+        // 이메일 내용 설정
         try {
             message.setFrom(user.getEmail());
             message.setRecipients(MimeMessage.RecipientType.TO, user.getEmail());
@@ -215,5 +223,7 @@ public class UserCommandServiceImpl implements UserCommandService {
         }
 
         javaMailSender.send(message);
+
+        return verificationCode;
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -333,6 +333,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
+    @Transactional
     public void findPw(UserRequestDTO.FindPwRequestDTO request) {
         Users user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -207,6 +207,17 @@ public class UserController {
         );
     }
 
+    @Operation(summary = "비밀번호 찾기 시 ID 존재여부 검증 API", description =
+            "# 비밀번호 찾기 시 ID 존재여부 검증 API 입니다. 비밀번호를 찾고자 하는 계정의 ID를 입력해주세요."
+    )
+    @GetMapping("/find/verify/id")
+    public ApiResponse<Object> verifyUsername(
+            @RequestParam String username
+    ) {
+        userCommandService.verifyUsername(username);
+        return ApiResponse.onSuccess("");
+    }
+
     @Operation(summary = "인증메일 발송 (PW 찾기)", description =
             "# 인증메일 발송 API 입니다. PW 찾기 시, 입력한 ID의 존재 여부, 이메일과 이름의 일치 여부를 확인 후 인증 메일을 발송합니다."
     )

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -189,14 +189,14 @@ public class UserController {
         return ApiResponse.onSuccess("");
     }
 
-    @Operation(summary = "인증메일 발송 (ID, PW 찾기)", description =
-        "# 인증메일 발송 API 입니다. ID, PW 찾기 시, 입력한 이메일과 이름의 일치 여부를 확인 후 인증 메일을 발송합니다."
+    @Operation(summary = "인증메일 발송 (ID 찾기)", description =
+        "# 인증메일 발송 API 입니다. ID 찾기 시, 입력한 이메일과 이름의 일치 여부를 확인 후 인증 메일을 발송합니다."
     )
-    @PostMapping("/find/send")
-    public ApiResponse<Object> sendVerificationMailFind(
-            @RequestBody UserRequestDTO.SendVerificationMailFindRequestDTO request
+    @PostMapping("/find/send-id")
+    public ApiResponse<Object> sendVerificationMailFindId(
+            @RequestBody UserRequestDTO.SendVerificationMailFindIdRequestDTO request
     ) {
-        userCommandService.sendVerificationMailFind(request);
+        userCommandService.sendVerificationMailFindId(request);
         return ApiResponse.onSuccess("");
     }
 
@@ -211,5 +211,4 @@ public class UserController {
                 userCommandService.findId(request)
         );
     }
-
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -227,6 +227,7 @@ public class UserController {
     ) {
         userCommandService.findPw(request);
         return ApiResponse.onSuccess("");
+    }
 
     @Operation(summary = "카카오 로그인 시 회원가입인지 로그인인지 확인하는 API", description =
                     "header에 'OpneId: {ID token}'형식으로 ID token을 입력해주세요.\n" +

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -211,4 +211,26 @@ public class UserController {
                 userCommandService.findId(request)
         );
     }
+
+    @Operation(summary = "인증메일 발송 (PW 찾기)", description =
+            "# 인증메일 발송 API 입니다. PW 찾기 시, 입력한 ID의 존재 여부, 이메일과 이름의 일치 여부를 확인 후 인증 메일을 발송합니다."
+    )
+    @PostMapping("/find/send-pw")
+    public ApiResponse<Object> sendVerificationMailFindPw(
+            @RequestBody UserRequestDTO.SendVerificationMailFindPwRequestDTO request
+    ) {
+        userCommandService.sendVerificationMailFindPw(request);
+        return ApiResponse.onSuccess("");
+    }
+
+    @Operation(summary = "PW 찾기", description =
+            "# PW 찾기 API 입니다. 이메일과 변경할 비밀번호를 입력해주세요."
+    )
+    @PostMapping("/find/pw")
+    public ApiResponse<Object> findPw(
+            @RequestBody UserRequestDTO.FindPwRequestDTO request
+    ) {
+        userCommandService.findPw(request);
+        return ApiResponse.onSuccess("");
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -167,6 +167,16 @@ public class UserController {
         );
     }
 
+    @Operation(summary = "인증번호 발송 API", description =
+            "# 인증번호 발송 API 입니다."
+    )
+    @PostMapping("/verify")
+    public ApiResponse<Object> sendVerificationMail() {
+        userCommandService.sendVerificationMail();
+        return ApiResponse.onSuccess("");
+    }
+
+
     // 미구현
     @Operation(summary = "인증번호 발송 API", description =
             "# 인증번호 발송 API 입니다. 인증번호를 발송할 이메일을 body에 입력해주세요."

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -168,51 +168,19 @@ public class UserController {
     }
 
     @Operation(summary = "인증번호 발송 API", description =
-            "# 인증번호 발송 API 입니다."
+            "# 인증번호 발송 API 입니다. 회원 정보에 등록된 이메일로 인증번호를 발송합니다."
     )
     @PostMapping("/verify")
-    public ApiResponse<Object> sendVerificationMail() {
-        userCommandService.sendVerificationMail();
-        return ApiResponse.onSuccess("");
-    }
-
-
-    // 미구현
-    @Operation(summary = "인증번호 발송 API", description =
-            "# 인증번호 발송 API 입니다. 인증번호를 발송할 이메일을 body에 입력해주세요."
-    )
-    @PostMapping("/code")
-    public ApiResponse<UserResponseDTO.SendVerificationCodeResultDTO> sendVerificationCode(
-            @RequestBody UserRequestDTO.SendVerificationCodeRequestDTO request
+    public ApiResponse<UserResponseDTO.SendVerificationMailResultDTO> sendVerificationMail(
+            @RequestBody UserRequestDTO.SendVerificationMailRequestDTO request
     ) {
+        Integer verificationCode = userCommandService.sendVerificationMail(request);
+
         return ApiResponse.onSuccess(
-                null
+                UserConverter.toSendVerificationMailResultDTO(
+                        verificationCode
+                )
         );
     }
 
-    // 미구현
-    @Operation(summary = "인증번호 확인 API (아이디 찾기용)", description =
-            "# 인증번호 확인 API 입니다 (아이디 찾기용). 확인할 인증코드를 query string에 입력해주세요."
-    )
-    @GetMapping("/verify/id")
-    public ApiResponse<UserResponseDTO.VerifyVerificationCodeForUsernameResultDTO> verifyVerificationCodeForUsername(
-            @RequestParam Integer verificationCode
-    ) {
-        return ApiResponse.onSuccess(
-                null
-        );
-    }
-
-    // 미구현
-    @Operation(summary = "인증번호 확인 API (비밀번호 찾기용)", description =
-            "# 인증번호 확인 API 입니다 (비밀번호 찾기용). 확인할 인증코드를 query string에 입력해주세요."
-    )
-    @GetMapping("/verify/pw")
-    public ApiResponse<UserResponseDTO.VerifyVerificationCodeForPasswordResultDTO> verifyVerificationCodeForPassword(
-            @RequestParam Integer verificationCode
-    ) {
-        return ApiResponse.onSuccess(
-                null
-        );
-    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -175,20 +175,41 @@ public class UserController {
             @RequestBody UserRequestDTO.SendVerificationMailSignUpRequestDTO request
     ) {
         userCommandService.sendVerificationMailSignUp(request);
-
         return ApiResponse.onSuccess("");
     }
 
-    @Operation(summary = "인증번호 확인 (회원가입)", description =
-            "# 인증번호 확인 API 입니다. 회원가입 시, 입력한 이메일로 발송된 인증번호를 입력해주세요."
+    @Operation(summary = "인증번호 확인", description =
+            "# 인증번호 확인 API 입니다. 입력한 이메일로 발송된 인증번호를 입력해주세요."
     )
     @PostMapping("/signup/verify/check")
     public ApiResponse<Object> checkVerificationCodeSignUp(
-            @RequestBody UserRequestDTO.CheckVerificationCodeSignUpRequestDTO request
+            @RequestBody UserRequestDTO.CheckVerificationCodeRequestDTO request
     ) {
-        userCommandService.checkVerificationCodeSignUp(request);
-
+        userCommandService.checkVerificationCode(request);
         return ApiResponse.onSuccess("");
+    }
+
+    @Operation(summary = "인증메일 발송 (ID, PW 찾기)", description =
+        "# 인증메일 발송 API 입니다. ID, PW 찾기 시, 입력한 이메일과 이름의 일치 여부를 확인 후 인증 메일을 발송합니다."
+    )
+    @PostMapping("/find/send")
+    public ApiResponse<Object> sendVerificationMailFind(
+            @RequestBody UserRequestDTO.SendVerificationMailFindRequestDTO request
+    ) {
+        userCommandService.sendVerificationMailFind(request);
+        return ApiResponse.onSuccess("");
+    }
+
+    @Operation(summary = "ID 찾기", description =
+            "# ID 찾기 API 입니다. 입력한 이메일로 발송된 인증번호를 입력해주세요."
+    )
+    @PostMapping("/find/id")
+    public ApiResponse<UserResponseDTO.FindIdResultDTO> findId(
+            @RequestBody UserRequestDTO.CheckVerificationCodeRequestDTO request
+    ) {
+        return ApiResponse.onSuccess(
+                userCommandService.findId(request)
+        );
     }
 
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -167,20 +167,28 @@ public class UserController {
         );
     }
 
-    @Operation(summary = "인증번호 발송 API", description =
-            "# 인증번호 발송 API 입니다. 회원 정보에 등록된 이메일로 인증번호를 발송합니다."
+    @Operation(summary = "인증메일 발송 (회원가입)", description =
+            "# 인증메일 발송 API 입니다. 회원가입 시, 입력한 이메일의 중복 여부를 확인 후 인증 메일을 발송합니다."
     )
-    @PostMapping("/verify")
-    public ApiResponse<UserResponseDTO.SendVerificationMailResultDTO> sendVerificationMail(
-            @RequestBody UserRequestDTO.SendVerificationMailRequestDTO request
+    @PostMapping("/signup/verify/send")
+    public ApiResponse<Object> sendVerificationMailSignUp(
+            @RequestBody UserRequestDTO.SendVerificationMailSignUpRequestDTO request
     ) {
-        Integer verificationCode = userCommandService.sendVerificationMail(request);
+        userCommandService.sendVerificationMailSignUp(request);
 
-        return ApiResponse.onSuccess(
-                UserConverter.toSendVerificationMailResultDTO(
-                        verificationCode
-                )
-        );
+        return ApiResponse.onSuccess("");
+    }
+
+    @Operation(summary = "인증번호 확인 (회원가입)", description =
+            "# 인증번호 확인 API 입니다. 회원가입 시, 입력한 이메일로 발송된 인증번호를 입력해주세요."
+    )
+    @PostMapping("/signup/verify/check")
+    public ApiResponse<Object> checkVerificationCodeSignUp(
+            @RequestBody UserRequestDTO.CheckVerificationCodeSignUpRequestDTO request
+    ) {
+        userCommandService.checkVerificationCodeSignUp(request);
+
+        return ApiResponse.onSuccess("");
     }
 
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -218,8 +218,8 @@ public class UserController {
         return ApiResponse.onSuccess("");
     }
 
-    @Operation(summary = "PW 찾기", description =
-            "# PW 찾기 API 입니다. 이메일과 변경할 비밀번호를 입력해주세요."
+    @Operation(summary = "PW 재설정", description =
+            "# PW 재설정 API 입니다. 이메일과 변경할 비밀번호를 입력해주세요."
     )
     @PostMapping("/find/pw")
     public ApiResponse<Object> findPw(

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -111,4 +111,28 @@ public class UserRequestDTO {
         @NotBlank(message = "이메일은 빈값일 수 없습니다.")
         private String email;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class SendVerificationMailFindPwRequestDTO {
+        @NotBlank(message = "아이디는 빈값일 수 없습니다.")
+        private String username;
+        @NotBlank(message = "이름은 빈값일 수 없습니다.")
+        private String name;
+        @NotBlank(message = "이메일은 빈값일 수 없습니다.")
+        private String email;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class FindPwRequestDTO {
+        @NotBlank(message = "이메일은 빈값일 수 없습니다.")
+        private String email;
+        @NotBlank(message = "비밀번호는 빈값일 수 없습니다.")
+        private String password;
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -105,7 +105,7 @@ public class UserRequestDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class SendVerificationMailFindRequestDTO {
+    public static class SendVerificationMailFindIdRequestDTO {
         @NotBlank(message = "이름은 빈값일 수 없습니다.")
         private String name;
         @NotBlank(message = "이메일은 빈값일 수 없습니다.")

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -85,10 +85,19 @@ public class UserRequestDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class SendVerificationMailRequestDTO {
-        @NotBlank(message = "이름은 빈값일 수 없습니다.")
-        private String name;
+    public static class SendVerificationMailSignUpRequestDTO {
         @NotBlank(message = "이메일은 빈값일 수 없습니다.")
         private String email;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CheckVerificationCodeSignUpRequestDTO {
+        @NotBlank(message = "이메일은 빈값일 수 없습니다.")
+        private String email;
+        @NotBlank(message = "인증번호는 빈값일 수 없습니다.")
+        private String code;
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -94,10 +94,21 @@ public class UserRequestDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class CheckVerificationCodeSignUpRequestDTO {
+    public static class CheckVerificationCodeRequestDTO {
         @NotBlank(message = "이메일은 빈값일 수 없습니다.")
         private String email;
         @NotBlank(message = "인증번호는 빈값일 수 없습니다.")
         private String code;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class SendVerificationMailFindRequestDTO {
+        @NotBlank(message = "이름은 빈값일 수 없습니다.")
+        private String name;
+        @NotBlank(message = "이메일은 빈값일 수 없습니다.")
+        private String email;
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -79,14 +79,16 @@ public class UserRequestDTO {
     @NoArgsConstructor
     public static class LogoutRequestDTO {
         private Long userId;
-    }  
-    
-    // 미구현  
+    }
+
     @Getter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class SendVerificationCodeRequestDTO {
-        private String email;  
+    public static class SendVerificationMailRequestDTO {
+        @NotBlank(message = "이름은 빈값일 수 없습니다.")
+        private String name;
+        @NotBlank(message = "이메일은 빈값일 수 없습니다.")
+        private String email;
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -69,4 +69,13 @@ public class UserResponseDTO {
         UserStatus status;
         Gender gender;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FindIdResultDTO {
+        String name;
+        String id;
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -69,31 +69,12 @@ public class UserResponseDTO {
         UserStatus status;
         Gender gender;
     }
-  
-    // 미구현
+
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class SendVerificationCodeResultDTO {
+    public static class SendVerificationMailResultDTO {
         Integer verificationCode;
-    }
-
-    // 미구현
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class VerifyVerificationCodeForUsernameResultDTO {
-        String username;
-    }
-
-    // 미구현
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class VerifyVerificationCodeForPasswordResultDTO {
-        String newPassword;
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -69,12 +69,4 @@ public class UserResponseDTO {
         UserStatus status;
         Gender gender;
     }
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class SendVerificationMailResultDTO {
-        Integer verificationCode;
-    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#83 

## 📝작업 내용
이메일 인증 API 구현

## 🔎코드 설명
**1. 인증메일 발송 (회원가입) API**
회원가입 과정에서 이메일 인증을 할 때 사용함.
입력한 이메일의 중복 여부를 확인, 사용가능하면 인증메일 발송

**2. 인증번호 확인 API**
회원가입, PW 찾기에서 인증번호 검증할 때 사용함.
입력한 이메일과 인증번호의 일치 여부를 확인함.

**3. 인증메일 발송 (ID 찾기) API**
ID 찾기과정에서 이메일 인증을 할 때 사용함.
입력한 이메일과 이름의 일치 여부를 확인, 일치한다면 인증메일 발송

**4. ID 찾기 API**
전달받은 인증번호를 입력하면, 검증 후 이름과 아이디를 반환해줌

**5. ID 존재여부 검증 API**
비밀번호 찾기과정 중 입력받은 아이디(username)가 존재하는지 확인

**6. 인증메일 발송 (PW 찾기) API**
PW 찾기과정에서 이메일 인증을 할 때 사용함.
입력한 아이디의 존재 여부, 이메일, 이름, 아이디의 일치 여부를 확인, 일치한다면 인증메일 발송

**7. PW 재설정 API**
이메일과 변경하고 싶은 비밀번호를 입력하면, 암호화 후 비밀번호를 변경함

### **<API 사용 순서>**
**회원가입 : 1 -> 2
ID 찾기 : 3 -> 4
PW 찾기 : 5 -> 6 -> 2 -> 7**

## 💬고민사항 및 리뷰 요구사항 (Optional)
여러가지 엮이는게 많아서 API가 여러개로 분산되었는데 어떻게 줄이면 좋을까요..

## 비고 (Optional)
현재 이메일이 단순 텍스트로 전달되기에, 추후 html을 활용하여 발전시킬 예정입니다.
