### PR TITLE
[Feat] 회원가입 시 아이디 입력 조건을 '아이디는 6 ~ 15자이어야 합니다.'로 변경

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -24,7 +24,7 @@ public class UserRequestDTO {
         @Size(max = 8, message = "닉네임은 1 ~ 8자이어야 합니다.")
         private String nickname;
         @NotBlank(message = "아이디는 빈값일 수 없습니다.")
-        @Size(max = 15, message = "아이디는 1 ~ 15자이어야 합니다.")
+        @Size(min = 6, max = 15, message = "아이디는 6 ~ 15자이어야 합니다.")
         private String username;
         @NotBlank(message = "비밀번호는 빈값일 수 없습니다.")
         private String password;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #133 

## 📝작업 내용
> 회원가입 시 아이디 입력 조건을 '아이디는 6 ~ 15자이어야 합니다.'로 변경

## 🔎코드 설명
> UserRequestDTO 클래스의 static inner class인 SignUpRequestDTO클래스의 @Size에 설정해둔 username의 입력조건을 "아이디는 6 ~ 15자이어야 합니다."로 변경

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
