### PR TITLE
[Feat] s3 이미지 리사이징 및 사진 회전 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 	implementation 'com.github.downgoon:marvin:1.5.5'
 	implementation 'com.github.downgoon:MarvinPlugins:1.5.5'
 
+	// s3 rotate
+	implementation 'com.drewnoakes:metadata-extractor:2.16.0'
+
 	//Jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,10 @@ dependencies {
 	//s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	//s3 resize marvin
+	implementation 'com.github.downgoon:marvin:1.5.5'
+	implementation 'com.github.downgoon:MarvinPlugins:1.5.5'
+
 	//Jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/TtattaBackend/ttatta/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/TtattaBackend/ttatta/aws/s3/AmazonS3Manager.java
@@ -4,15 +4,24 @@ import TtattaBackend.ttatta.config.AmazonConfig;
 import TtattaBackend.ttatta.domain.Uuid;
 import TtattaBackend.ttatta.repository.UuidRepository;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import marvin.image.MarvinImage;
+import org.marvinproject.image.transform.scale.Scale;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 @Slf4j
 @Component
@@ -26,14 +35,19 @@ public class AmazonS3Manager{
     private final UuidRepository uuidRepository;
 
     public String uploadFile(String keyName, MultipartFile file){
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentLength(file.getSize());
+        String originalFilename = file.getOriginalFilename();
+        String fileFormatName = file.getContentType().substring(file.getContentType().lastIndexOf("/") + 1);
 
+        MultipartFile resizedFile = resizeImageByMarvin(keyName, originalFilename, fileFormatName, file, 400);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(resizedFile.getSize());
         metadata.setContentDisposition("inline");
         metadata.setContentType(file.getContentType());
 
-        try {
-            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
+        try(InputStream inputStream = resizedFile.getInputStream()) {
+            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, inputStream, metadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
         } catch (IOException e){
             log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
         }
@@ -54,6 +68,36 @@ public class AmazonS3Manager{
             amazonS3.deleteObject(new DeleteObjectRequest(amazonConfig.getBucket(), keyName));
         } catch (Exception e) {
             log.error("error at AmazonS3Manager deleteFile : {}", (Object) e.getStackTrace());
+        }
+    }
+
+    MultipartFile resizeImageByMarvin(String fileName, String originalFilename, String fileFormatName, MultipartFile originalImage, int targetWidth) {
+        try {
+            // MultipartFile -> BufferedImage Convert
+            BufferedImage image = ImageIO.read(originalImage.getInputStream());
+            // newWidth : newHeight = originWidth : originHeight
+            int originWidth = image.getWidth();
+            int originHeight = image.getHeight();
+
+            // origin 이미지가 resizing될 사이즈보다 작을 경우 resizing 작업 안 함
+            if(originWidth < targetWidth)
+                return originalImage;
+            MarvinImage imageMarvin = new MarvinImage(image);
+
+            Scale scale = new Scale();
+            scale.load();
+            scale.setAttribute("newWidth", targetWidth);
+            scale.setAttribute("newHeight", targetWidth * originHeight / originWidth);
+            scale.process(imageMarvin.clone(), imageMarvin, null, null, false);
+
+            BufferedImage imageNoAlpha = imageMarvin.getBufferedImageNoAlpha();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageIO.write(imageNoAlpha, fileFormatName, baos);
+            baos.flush();
+
+            return new CustomMultipartFile(fileName, originalFilename, fileFormatName, baos.toByteArray());
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 리사이즈에 실패했습니다.");
         }
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/TtattaBackend/ttatta/aws/s3/AmazonS3Manager.java
@@ -18,10 +18,18 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 import javax.imageio.ImageIO;
+import java.awt.geom.AffineTransform;
+import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+
+import com.drew.metadata.*;
+import com.drew.metadata.exif.ExifIFD0Directory;
+import com.drew.imaging.ImageMetadataReader;
+
 
 @Slf4j
 @Component
@@ -38,7 +46,7 @@ public class AmazonS3Manager{
         String originalFilename = file.getOriginalFilename();
         String fileFormatName = file.getContentType().substring(file.getContentType().lastIndexOf("/") + 1);
 
-        MultipartFile resizedFile = resizeImageByMarvin(keyName, originalFilename, fileFormatName, file, 400);
+        MultipartFile resizedFile = resizeImageByMarvin(keyName, originalFilename, fileFormatName, file, 1000);
 
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(resizedFile.getSize());
@@ -73,13 +81,15 @@ public class AmazonS3Manager{
 
     MultipartFile resizeImageByMarvin(String fileName, String originalFilename, String fileFormatName, MultipartFile originalImage, int targetWidth) {
         try {
-            // MultipartFile -> BufferedImage Convert
-            BufferedImage image = ImageIO.read(originalImage.getInputStream());
-            // newWidth : newHeight = originWidth : originHeight
+            InputStream imageStream = new ByteArrayInputStream(originalImage.getBytes());
+            BufferedImage image = ImageIO.read(imageStream);
+
+            image = correctImageOrientation(image, originalImage);
+
             int originWidth = image.getWidth();
             int originHeight = image.getHeight();
 
-            // origin 이미지가 resizing될 사이즈보다 작을 경우 resizing 작업 안 함
+            // origin 이미지가 resizing될 사이즈보다 작을 경우 작업 안함
             if(originWidth < targetWidth)
                 return originalImage;
             MarvinImage imageMarvin = new MarvinImage(image);
@@ -99,5 +109,41 @@ public class AmazonS3Manager{
         } catch (IOException e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 리사이즈에 실패했습니다.");
         }
+    }
+
+    private BufferedImage correctImageOrientation(BufferedImage image, MultipartFile file) {
+        try {
+            InputStream inputStream = new ByteArrayInputStream(file.getBytes());
+            Metadata metadata = ImageMetadataReader.readMetadata(inputStream);
+            ExifIFD0Directory directory = metadata.getFirstDirectoryOfType(ExifIFD0Directory.class);
+
+            if (directory != null && directory.containsTag(ExifIFD0Directory.TAG_ORIENTATION)) {
+                int orientation = directory.getInt(ExifIFD0Directory.TAG_ORIENTATION);
+                return rotateImage(image, orientation);
+            }
+        } catch (Exception e) {
+            log.warn("EXIF 데이터를 읽을 수 없습니다. 기본 방향으로 저장합니다.");
+        }
+        return image;
+    }
+
+
+    private BufferedImage rotateImage(BufferedImage image, int orientation) {
+        AffineTransform transform = new AffineTransform();
+        switch (orientation) {
+            case 6: // 90도 회전
+                transform.rotate(Math.toRadians(90), image.getWidth() / 2.0, image.getHeight() / 2.0);
+                break;
+            case 3: // 180도 회전
+                transform.rotate(Math.toRadians(180), image.getWidth() / 2.0, image.getHeight() / 2.0);
+                break;
+            case 8: // 270도 회전
+                transform.rotate(Math.toRadians(270), image.getWidth() / 2.0, image.getHeight() / 2.0);
+                break;
+            default:
+                return image; // 회전 필요 없음
+        }
+        AffineTransformOp op = new AffineTransformOp(transform, AffineTransformOp.TYPE_BILINEAR);
+        return op.filter(image, null);
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/aws/s3/CustomMultipartFile.java
+++ b/src/main/java/TtattaBackend/ttatta/aws/s3/CustomMultipartFile.java
@@ -1,0 +1,67 @@
+package TtattaBackend.ttatta.aws.s3;
+
+import org.springframework.util.FileCopyUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class CustomMultipartFile implements MultipartFile {
+
+    private final String fileName;
+
+    private String originalFilename;
+
+    private String contentType;
+
+    private final byte[] content;
+
+    public CustomMultipartFile(String fileName, String originalFilename, String contentType, byte[] content) {
+        this.fileName = fileName;
+        this.originalFilename = (originalFilename != null ? originalFilename : "");
+        this.contentType = contentType;
+        this.content = (content != null ? content : new byte[0]);
+    }
+
+    @Override
+    public String getName() {
+        return this.fileName;
+    }
+
+    @Override
+    public String getOriginalFilename() {
+        return this.originalFilename;
+    }
+
+    @Override
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return (this.content.length == 0);
+    }
+
+    @Override
+    public long getSize() {
+        return this.content.length;
+    }
+
+    @Override
+    public byte[] getBytes() throws IOException {
+        return this.content;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return new ByteArrayInputStream(this.content);
+    }
+
+    @Override
+    public void transferTo(File dest) throws IOException, IllegalStateException {
+        FileCopyUtils.copy(this.content, dest);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #131 

## 📝작업 내용
> 용량 큰 이미지들 리사이징 후 저장

## 🔎코드 설명
> 이미지 업로드 요청 들어오면 이미지 리사이징 후 s3에 저장
> 이후 객체 url 받아옴

## 💬고민사항 및 리뷰 요구사항 (Optional)
> build.gradle에 marvin이 추가되었습니다..:)
> 생각보다 다운 많이 받더라고요..ㅎㅎ 노트북 용량 주의

## s3(낙우새 사진)
- 원래 3.0MB 짜리입니다. 

<img width="112" alt="스크린샷 2025-02-20 오전 1 31 24" src="https://github.com/user-attachments/assets/a3703205-c12c-4507-828c-92d72519838a" />
<img width="798" alt="스크린샷 2025-02-20 오전 1 32 39" src="https://github.com/user-attachments/assets/6e77ba9d-defd-4949-9a0c-c87b861ea39f" />

