### PR TITLE
[Feat] 관리자용 회원 삭제 API 구현

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -27,4 +27,5 @@ public interface UserCommandService {
     void findPw(UserRequestDTO.FindPwRequestDTO request);
     UserResponseDTO.TokenValidationResultDTO validateToken(String openId);
     Long getUserPoint();
+    void deleteUserByAdmin(Long userId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -419,5 +419,13 @@ public class UserCommandServiceImpl implements UserCommandService {
         redisTemplate.opsForValue().set(key, refreshToken, refreshExpTime, TimeUnit.MINUTES);
         return refreshToken;
     }
+
+    @Override
+    public void deleteUserByAdmin(Long userId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        userRepository.delete(user);
+    }
 }
 

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -254,4 +254,15 @@ public class UserController {
                 userCommandService.validateToken(openId)
         );
     }
+
+    @Operation(summary = "[관리자용] 회원 삭제", description =
+            "# 관리자용 API입니다. 삭제할 회원의 ID를 입력해주세요. (사용 주의)"
+    )
+    @DeleteMapping("/{userId}")
+    public ApiResponse<Object> deleteUserByAdmin(
+            @PathVariable Long userId
+    ) {
+        userCommandService.deleteUserByAdmin(userId);
+        return ApiResponse.onSuccess("");
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#141 

## 📝작업 내용
관리자용 회원 삭제 API 구현

## 🔎코드 설명
pathVariable로 회원 ID를 입력하면 해당 회원 정보와 관련된 일기가 모두 삭제됩니다.
관리자용 API이므로 사용에 유의해야합니다.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
