### PR TITLE
[Fix] open id 검증 수정

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/oidc/JwtOIDCProvider.java
+++ b/src/main/java/TtattaBackend/ttatta/oidc/JwtOIDCProvider.java
@@ -20,7 +20,7 @@ public class JwtOIDCProvider {
     // Header, body, VerifyingSignature 중에서 Header와 body만 가져옴
     private String getUnsignedToken(String token) {
         String[] splitToken = token.split("\\.");
-        if (splitToken.length == 3) throw new ExceptionHandler(ErrorStatus.INVALID_TOKEN);
+        if (splitToken.length != 3) throw new ExceptionHandler(ErrorStatus.INVALID_TOKEN);
         return splitToken[0] + "." + splitToken[1] + ".";
     }
 
@@ -36,7 +36,9 @@ public class JwtOIDCProvider {
         } catch (ExpiredJwtException e) {
             throw new ExceptionHandler(ErrorStatus.TOKEN_EXPIRED);
         } catch (Exception e) {
-            throw new ExceptionHandler(ErrorStatus.INVALID_TOKEN);
+            System.out.println("1JWT error: " + e.getMessage());
+            throw new ExceptionHandler(ErrorStatus.TOKEN_ERROR);
+//            throw new ExceptionHandler(ErrorStatus.INVALID_TOKEN);
         }
     }
 

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -54,7 +54,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Value("${oidc.iss}")
     private String iss;
 
-    @Value("{oidc.aud}")
+    @Value("${oidc.aud}")
     private String aud;
 
     private final UserRepository userRepository;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #158 

## 📝작업 내용
> open id 검증 부분 수정

## 🔎코드 설명
> UserCommandServiceImpl -> @Value("${oidc.aud}") -> $ 추가
> JwtOIDCProvider에서 splitToken 은 처음에 3개가 맞기 때문에 ==로 수정

## 💬고민사항 및 리뷰 요구사항 (Optional)
> access token 및 refresh token은 null 값으로 나옴..

## 비고 (Optional)
>
<img width="813" alt="스크린샷 2025-03-22 오후 5 53 57" src="https://github.com/user-attachments/assets/76aaf7ea-2a3c-470f-8aeb-e0eae8d5e406" />

