### PR TITLE
[Refactor] 닉네임 관련 보안 이슈 설정

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/TtattaApplication.java
+++ b/src/main/java/TtattaBackend/ttatta/TtattaApplication.java
@@ -7,12 +7,15 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableFeignClients(basePackages = "TtattaBackend.ttatta.oidc")
 @EnableCaching
 @EnableConfigurationProperties(OauthProperties.class)
+// Pending User 삭제용
+@EnableScheduling
 public class TtattaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -48,6 +48,7 @@ public enum ErrorStatus implements BaseErrorCode {
     REFRESHTOKEN_NOT_EQUAL(HttpStatus.NOT_FOUND, "TOKEN_4004", "refresh token이 일치하지 않습니다."),
     TOKEN_EXPIRED(HttpStatus.BAD_REQUEST,"TOKEN_4005","토큰이 만료되었습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST,"TOKEN_4006","유효하지 않은 토큰입니다."),
+    INVALID_OPEN_ID(HttpStatus.BAD_REQUEST,"TOKEN_4007","유효하지 않은 open id 입니다"),
 
     // 아이템 관련 응답 5000
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND,"ITEM_5001","아이템이 없습니다."),

--- a/src/main/java/TtattaBackend/ttatta/config/security/SecurityUtil.java
+++ b/src/main/java/TtattaBackend/ttatta/config/security/SecurityUtil.java
@@ -14,7 +14,9 @@ public class SecurityUtil {
     public static Long getCurrentUserId() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication == null || authentication.getName() == null) {
+        if (authentication == null || authentication.getName() == null
+                || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getName())) {
             throw  new RuntimeException("Security Context 에 인증 정보가 없습니다.");
         }
 

--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -3,6 +3,7 @@ package TtattaBackend.ttatta.converter;
 import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.domain.enums.IsAvailable;
 import TtattaBackend.ttatta.domain.enums.LoginType;
+import TtattaBackend.ttatta.domain.enums.UserStatus;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserResponseDTO;
 
@@ -21,15 +22,15 @@ public class UserConverter {
                 .build();
     }
 
-    public static Users toKakaoUsers(UserRequestDTO.SignUpKakaoRequestDTO request, String sub) {
+    public static Users toKakaoUsers(String sub) {
         return Users.builder()
                 .name(null)
                 .email(null)
                 .password(null)
                 .username(null)
+                .status(UserStatus.PENDING)
                 .diaryCategoriesList(new ArrayList<>())
                 .providerId(sub)
-                .nickname(request.getNickname())
                 .loginType(LoginType.KAKAO)
                 .build();
     }
@@ -43,8 +44,18 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.UserKaKaoSignUpResultDTO toUserKaKaoSignUpResultDTO(String accessToken, String refreshToken, Users users) {
-        return UserResponseDTO.UserKaKaoSignUpResultDTO.builder()
+    public static UserResponseDTO.UserKaKaoOpenIdResultDTO toUserKaKaoOpenIdResultDTO(String accessToken, String refreshToken, Users users) {
+        return UserResponseDTO.UserKaKaoOpenIdResultDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .userId(users.getId())
+                .loginType(users.getLoginType())
+                .createdAt(users.getCreatedAt())
+                .build();
+    }
+
+    public static UserResponseDTO.KaKaoFinalSignUpResultDTO toUserKaKaoFinalSignUpResultDTO(String accessToken, String refreshToken, Users users) {
+        return UserResponseDTO.KaKaoFinalSignUpResultDTO.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .userId(users.getId())

--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -122,12 +122,4 @@ public class UserConverter {
                 .status(users.getStatus())
                 .build();
     }
-
-//    public static UserResponseDTO.TokenValidationResultDTO toTokenValidationResultDTO(OauthInfo oauthInfo) {
-//        return UserResponseDTO.TokenValidationResultDTO.builder()
-//                .isRegistered(false) // 수정 필요
-//                .accessToken()
-//                .refreshToken()
-//                .build();
-//    }
 }

--- a/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/UserConverter.java
@@ -44,8 +44,9 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.UserKaKaoOpenIdResultDTO toUserKaKaoOpenIdResultDTO(String accessToken, String refreshToken, Users users) {
+    public static UserResponseDTO.UserKaKaoOpenIdResultDTO toUserKaKaoOpenIdResultDTO(Boolean isRegistered,String accessToken, String refreshToken, Users users) {
         return UserResponseDTO.UserKaKaoOpenIdResultDTO.builder()
+                .isRegistered(isRegistered)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .userId(users.getId())

--- a/src/main/java/TtattaBackend/ttatta/domain/Users.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Users.java
@@ -5,6 +5,7 @@ import TtattaBackend.ttatta.domain.enums.Gender;
 import TtattaBackend.ttatta.domain.enums.LoginType;
 import TtattaBackend.ttatta.domain.enums.UserStatus;
 import TtattaBackend.ttatta.domain.mapping.OwnedItems;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
@@ -31,7 +32,7 @@ public class Users extends BaseEntity {
     @Column
     private String name;
 
-    @Column(length = 8)
+    @Column(length = 8, nullable = true)
     private String nickname;
 
     @Column(length = 15)
@@ -95,4 +96,5 @@ public class Users extends BaseEntity {
         this.profileImage = profileImage;
     }
     public void updatePoint(Long point) {this.point = point;}
+    public void updateStatus(UserStatus status) {this.status = status;}
 }

--- a/src/main/java/TtattaBackend/ttatta/domain/Users.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Users.java
@@ -31,7 +31,7 @@ public class Users extends BaseEntity {
     @Column
     private String name;
 
-    @Column(nullable = false, length = 8)
+    @Column(length = 8)
     private String nickname;
 
     @Column(length = 15)

--- a/src/main/java/TtattaBackend/ttatta/domain/enums/UserStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/enums/UserStatus.java
@@ -1,5 +1,5 @@
 package TtattaBackend.ttatta.domain.enums;
 
 public enum UserStatus {
-    ACTIVE, INACTIVE
+    ACTIVE, INACTIVE, PENDING
 }

--- a/src/main/java/TtattaBackend/ttatta/jwt/JwtUtils.java
+++ b/src/main/java/TtattaBackend/ttatta/jwt/JwtUtils.java
@@ -163,12 +163,4 @@ public class JwtUtils {
             }
         }
     }
-
-    public Long extractUserId(String token) {
-        Claims claims = Jwts.parser()
-                .setSigningKey(secretKey.getBytes())
-                .parseClaimsJws(token)
-                .getBody();
-        return Long.parseLong(claims.getSubject());
-    }
 }

--- a/src/main/java/TtattaBackend/ttatta/jwt/JwtUtils.java
+++ b/src/main/java/TtattaBackend/ttatta/jwt/JwtUtils.java
@@ -163,4 +163,12 @@ public class JwtUtils {
             }
         }
     }
+
+    public Long extractUserId(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(secretKey.getBytes())
+                .parseClaimsJws(token)
+                .getBody();
+        return Long.parseLong(claims.getSubject());
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/UserRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/UserRepository.java
@@ -1,9 +1,11 @@
 package TtattaBackend.ttatta.repository;
 
 import TtattaBackend.ttatta.domain.Users;
+import TtattaBackend.ttatta.domain.enums.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +15,5 @@ public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByEmail(String email);
     boolean existsByUsername(String username);
     Optional<Users> findByProviderId(String providerId);
+    void deleteByStatusAndCreatedAtBefore(UserStatus status, LocalDateTime dateTime);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/PendingUserCleanUpService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/PendingUserCleanUpService.java
@@ -1,0 +1,25 @@
+package TtattaBackend.ttatta.service.UserService;
+
+import TtattaBackend.ttatta.domain.enums.UserStatus;
+import TtattaBackend.ttatta.repository.UserRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class PendingUserCleanUpService {
+    private final UserRepository userRepository;
+
+    public PendingUserCleanUpService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    // 매일 00:00에 실행 (원하는 주기/시간으로 조정 가능)
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void removeExpiredPendingUsers() {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(7);
+        userRepository.deleteByStatusAndCreatedAtBefore(UserStatus.PENDING, cutoff);
+        // 필요하면 삭제된 개수를 로그로 남겨도 좋습니다.
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -14,6 +14,7 @@ public interface UserCommandService {
     UserResponseDTO.RefreshResultDTO refresh(String refreshToken);
     UserResponseDTO.UserKaKaoOpenIdResultDTO openIdKakao(String openId);
     UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(UserRequestDTO.SignUpKakaoRequestDTO request);
+    UserResponseDTO.IsPendingResultDTO checkIsPending();
 //    Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
     UserResponseDTO.UserInfoResultDTO getUserInfo();
     Users editUserInfo(UserRequestDTO.EditRequestDTO request);

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -12,7 +12,8 @@ public interface UserCommandService {
     void logout(String accessToken);
     UserResponseDTO.UserSignInResultDTO signIn(UserRequestDTO.SignInRequestDTO request);
     UserResponseDTO.RefreshResultDTO refresh(String refreshToken);
-    UserResponseDTO.UserKaKaoSignUpResultDTO signUpKakao(String openId, UserRequestDTO.SignUpKakaoRequestDTO request);
+    UserResponseDTO.UserKaKaoOpenIdResultDTO openIdKakao(String openId);
+    UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(String openId, UserRequestDTO.SignUpKakaoRequestDTO request);
 //    Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
     UserResponseDTO.UserInfoResultDTO getUserInfo();
     Users editUserInfo(UserRequestDTO.EditRequestDTO request);

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -13,7 +13,7 @@ public interface UserCommandService {
     UserResponseDTO.UserSignInResultDTO signIn(UserRequestDTO.SignInRequestDTO request);
     UserResponseDTO.RefreshResultDTO refresh(String refreshToken);
     UserResponseDTO.UserKaKaoOpenIdResultDTO openIdKakao(String openId);
-    UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(String accessToken, UserRequestDTO.SignUpKakaoRequestDTO request);
+    UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(UserRequestDTO.SignUpKakaoRequestDTO request);
 //    Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
     UserResponseDTO.UserInfoResultDTO getUserInfo();
     Users editUserInfo(UserRequestDTO.EditRequestDTO request);

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -13,7 +13,7 @@ public interface UserCommandService {
     UserResponseDTO.UserSignInResultDTO signIn(UserRequestDTO.SignInRequestDTO request);
     UserResponseDTO.RefreshResultDTO refresh(String refreshToken);
     UserResponseDTO.UserKaKaoOpenIdResultDTO openIdKakao(String openId);
-    UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(String openId, UserRequestDTO.SignUpKakaoRequestDTO request);
+    UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(String accessToken, UserRequestDTO.SignUpKakaoRequestDTO request);
 //    Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
     UserResponseDTO.UserInfoResultDTO getUserInfo();
     Users editUserInfo(UserRequestDTO.EditRequestDTO request);
@@ -26,7 +26,7 @@ public interface UserCommandService {
     void verifyUsername(String username);
     void sendVerificationMailFindPw(UserRequestDTO.SendVerificationMailFindPwRequestDTO request);
     void findPw(UserRequestDTO.FindPwRequestDTO request);
-    UserResponseDTO.TokenValidationResultDTO validateToken(String openId);
+//    UserResponseDTO.TokenValidationResultDTO validateToken(String openId);
     Long getUserPoint();
     void deleteUserByAdmin(Long userId);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -181,8 +181,9 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Transactional
     public UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(String accessToken, UserRequestDTO.SignUpKakaoRequestDTO request) {
 
-        Long savedUserId = JwtUtils.extractUserId(accessToken);
-        Users savedUser = userRepository.findById(savedUserId)
+//        Long savedUserId = jwtUtils.extractUserId(accessToken);
+        Long userId = SecurityUtil.getCurrentUserId();
+        Users savedUser = userRepository.findById(userId)
                 .orElseThrow(() -> new ExceptionHandler(ErrorStatus.USER_NOT_FOUND));
 
         // 해당 닉네임을 업데이트

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -101,6 +101,19 @@ public class UserCommandServiceImpl implements UserCommandService {
         return userRepository.save(newUser);
     }
 
+    @Override
+    @Transactional
+    public UserResponseDTO.IsPendingResultDTO checkIsPending() {
+        Long UserId = SecurityUtil.getCurrentUserId();
+        Users user = userRepository.findById(UserId)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        boolean isPending = user.getStatus().equals(UserStatus.PENDING);
+        return UserResponseDTO.IsPendingResultDTO.builder()
+                .isPending(isPending)
+                .build();
+    }
+
     // open id 인증 완료 한 후 1. 로그인을 시키거나, 2. 가입 대기상태의 유저로 임시 회원가입 처리
     @Override
     @Transactional

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package TtattaBackend.ttatta.service.UserService;
 
+import TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus;
 import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
 import TtattaBackend.ttatta.config.security.SecurityUtil;
 import TtattaBackend.ttatta.converter.DiaryCategoryConverter;
@@ -98,29 +99,78 @@ public class UserCommandServiceImpl implements UserCommandService {
         return userRepository.save(newUser);
     }
 
-    // open id 인증 완료 한 후 가입 대기상태의 유저로 처리.
+
+    public UserResponseDTO.TokenValidationResultDTO validateToken(String openId) {
+        // 공개키 가져오기
+        OIDCPublicKeyResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
+
+        // 페이로드 검증 && 서명 검증 후 sub 값 기준으로 회원가입 or 로그인 처리
+        OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(openId, iss, aud, oidcPublicKeysResponse);
+        String sub = oidcDecodePayload.getSub();
+
+        if (sub == null || sub.isEmpty()) {
+            return new UserResponseDTO.TokenValidationResultDTO(false, "access token", "refresh token");
+        }
+
+        Optional<Users> userSub = userRepository.findByProviderId(sub);
+
+        if (userSub.isPresent()) {
+            // 사용자가 이미 존재하면 로그인 처리 (토큰 반환)
+            Users user = userSub.get();
+
+            // 액세스 토큰 및 리프레시 토큰 생성
+            String key = "users:" + user.getId().toString();
+            String accessToken = generateAccessToken(user.getId(), accessExpTime);
+            String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
+
+            return new UserResponseDTO.TokenValidationResultDTO(true, accessToken, refreshToken);
+        } else {
+            return new UserResponseDTO.TokenValidationResultDTO(true, null, null);
+        }
+    }
+
+    // open id 인증 완료 한 후 로그인을 시키거나, 가입 대기상태의 유저로 임시 회원가입 처리
     @Override
     @Transactional
     public UserResponseDTO.UserKaKaoOpenIdResultDTO openIdKakao(String openId) {
 
-        // openId를 통해 sub 추출하기
+        // 공개키 가져오기
         OIDCPublicKeyResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
+        // 페이로드 검증 && 서명 후 sub 값 추출
         OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(openId, iss, aud, oidcPublicKeysResponse);
         String sub = oidcDecodePayload.getSub();
 
-        // 새로운 유저 생성
-        Users newUser = UserConverter.toKakaoUsers(sub);
 
-        // 회원 정보 db에 저장
-        Users savedUser = userRepository.save(newUser);
+        // sub가 없다면 에러처리
+        if (sub == null || sub.isEmpty()) {
+            throw new ExceptionHandler(INVALID_OPEN_ID);
+        }
 
-//        // 일상 카테고리 생성
-//        createDefaultCategory(newUser);
-        // 액세스 토큰 및 리프레시 토큰 생성
-        String key = "users:" + savedUser.getId().toString();
-        String accessToken = generateAccessToken(savedUser.getId(), accessExpTime);
-        String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
-        return UserConverter.toUserKaKaoOpenIdResultDTO(accessToken, refreshToken, savedUser);
+        Optional<Users> userSub = userRepository.findByProviderId(sub);
+
+        // sub 추출 완료
+        // sub의 user 가 존재한다면 -> 로그인 처리 => access token, refresh token 리턴
+        if (userSub.isPresent()) {
+            Users ExistUser = userSub.get();
+            String key = ExistUser.getId().toString();
+            String accessToken = generateAccessToken(userSub.get().getId(), accessExpTime);
+            String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
+            return UserConverter.toUserKaKaoOpenIdResultDTO(true, accessToken, refreshToken, userSub.get());
+        }
+        // sub가 잘 추출되었지만, 회원 db에 없어 임시 회원가입 처리 해야하는 부분
+        else {
+            // 새로운 유저 생성
+            Users newUser = UserConverter.toKakaoUsers(sub);
+
+            // 회원 정보 db에 저장
+            Users savedUser = userRepository.save(newUser);
+
+            // 액세스 토큰 및 리프레시 토큰 생성
+            String key = "users:" + savedUser.getId().toString();
+            String accessToken = generateAccessToken(savedUser.getId(), accessExpTime);
+            String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
+            return UserConverter.toUserKaKaoOpenIdResultDTO(false, accessToken, refreshToken, savedUser);
+        }
     }
 
     // Nickname 입력받고 회원 상태 업데이트
@@ -401,35 +451,6 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         // 새 비밀번호 암호화 후 업데이트
         user.encodePassword(passwordEncoder.encode(request.getPassword()));
-    }
-
-    public UserResponseDTO.TokenValidationResultDTO validateToken(String openId) {
-        // 공개키 가져오기
-        OIDCPublicKeyResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
-
-        // 페이로드 검증 && 서명 검증 후 sub 값 기준으로 회원가입 or 로그인 처리
-        OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(openId, iss, aud, oidcPublicKeysResponse);
-        String sub = oidcDecodePayload.getSub();
-
-        if (sub == null || sub.isEmpty()) {
-            return new UserResponseDTO.TokenValidationResultDTO(false, "access token", "refresh token");
-        }
-
-        Optional<Users> userSub = userRepository.findByProviderId(sub);
-
-        if (userSub.isPresent()) {
-            // 사용자가 이미 존재하면 로그인 처리 (토큰 반환)
-            Users user = userSub.get();
-
-            // 액세스 토큰 및 리프레시 토큰 생성
-            String key = "users:" + user.getId().toString();
-            String accessToken = generateAccessToken(user.getId(), accessExpTime);
-            String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
-
-            return new UserResponseDTO.TokenValidationResultDTO(true, accessToken, refreshToken);
-        } else {
-            return new UserResponseDTO.TokenValidationResultDTO(true, null, null);
-        }
     }
 
     @Override

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -2,6 +2,7 @@ package TtattaBackend.ttatta.service.UserService;
 
 import TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus;
 import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
+import TtattaBackend.ttatta.config.security.JwtAuthenticationFilter;
 import TtattaBackend.ttatta.config.security.SecurityUtil;
 import TtattaBackend.ttatta.converter.DiaryCategoryConverter;
 import TtattaBackend.ttatta.converter.UserConverter;
@@ -47,6 +48,7 @@ import static TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus.*;
 public class UserCommandServiceImpl implements UserCommandService {
 
     private final OauthOIDCHelper oauthOIDCHelper;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
     @Value("${jwt.ACCESS_EXP_TIME}")
     private int accessExpTime;
     @Value("${jwt.REFRESH_EXP_TIME}")
@@ -100,36 +102,36 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
 
-    public UserResponseDTO.TokenValidationResultDTO validateToken(String openId) {
-        // 공개키 가져오기
-        OIDCPublicKeyResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
+//    public UserResponseDTO.TokenValidationResultDTO validateToken(String openId) {
+//        // 공개키 가져오기
+//        OIDCPublicKeyResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
+//
+//        // 페이로드 검증 && 서명 검증 후 sub 값 기준으로 회원가입 or 로그인 처리
+//        OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(openId, iss, aud, oidcPublicKeysResponse);
+//        String sub = oidcDecodePayload.getSub();
+//
+//        if (sub == null || sub.isEmpty()) {
+//            return new UserResponseDTO.TokenValidationResultDTO(false, "access token", "refresh token");
+//        }
+//
+//        Optional<Users> userSub = userRepository.findByProviderId(sub);
+//
+//        if (userSub.isPresent()) {
+//            // 사용자가 이미 존재하면 로그인 처리 (토큰 반환)
+//            Users user = userSub.get();
+//
+//            // 액세스 토큰 및 리프레시 토큰 생성
+//            String key = "users:" + user.getId().toString();
+//            String accessToken = generateAccessToken(user.getId(), accessExpTime);
+//            String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
+//
+//            return new UserResponseDTO.TokenValidationResultDTO(true, accessToken, refreshToken);
+//        } else {
+//            return new UserResponseDTO.TokenValidationResultDTO(true, null, null);
+//        }
+//    }
 
-        // 페이로드 검증 && 서명 검증 후 sub 값 기준으로 회원가입 or 로그인 처리
-        OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(openId, iss, aud, oidcPublicKeysResponse);
-        String sub = oidcDecodePayload.getSub();
-
-        if (sub == null || sub.isEmpty()) {
-            return new UserResponseDTO.TokenValidationResultDTO(false, "access token", "refresh token");
-        }
-
-        Optional<Users> userSub = userRepository.findByProviderId(sub);
-
-        if (userSub.isPresent()) {
-            // 사용자가 이미 존재하면 로그인 처리 (토큰 반환)
-            Users user = userSub.get();
-
-            // 액세스 토큰 및 리프레시 토큰 생성
-            String key = "users:" + user.getId().toString();
-            String accessToken = generateAccessToken(user.getId(), accessExpTime);
-            String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
-
-            return new UserResponseDTO.TokenValidationResultDTO(true, accessToken, refreshToken);
-        } else {
-            return new UserResponseDTO.TokenValidationResultDTO(true, null, null);
-        }
-    }
-
-    // open id 인증 완료 한 후 로그인을 시키거나, 가입 대기상태의 유저로 임시 회원가입 처리
+    // open id 인증 완료 한 후 1. 로그인을 시키거나, 2. 가입 대기상태의 유저로 임시 회원가입 처리
     @Override
     @Transactional
     public UserResponseDTO.UserKaKaoOpenIdResultDTO openIdKakao(String openId) {
@@ -177,15 +179,11 @@ public class UserCommandServiceImpl implements UserCommandService {
     // 여기서 일상 카테고리 만들어도 될듯!
     @Override
     @Transactional
-    public UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(String openId, UserRequestDTO.SignUpKakaoRequestDTO request) {
-        // openId를 통해 sub 추출하기
-        OIDCPublicKeyResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
-        OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(openId, iss, aud, oidcPublicKeysResponse);
-        String sub = oidcDecodePayload.getSub();
+    public UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(String accessToken, UserRequestDTO.SignUpKakaoRequestDTO request) {
 
-        // openId를 이용해 db에 있는 회원 찾기
-        Users savedUser = userRepository.findByProviderId(sub)
-                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+        Long savedUserId = JwtUtils.extractUserId(accessToken);
+        Users savedUser = userRepository.findById(savedUserId)
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus.USER_NOT_FOUND));
 
         // 해당 닉네임을 업데이트
         savedUser.updateNickname(request.getNickname());
@@ -198,7 +196,6 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         // 액세스 토큰 및 리프레시 토큰 생성
         String key = "users:" + savedUser.getId().toString();
-        String accessToken = generateAccessToken(savedUser.getId(), accessExpTime);
         String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
 
         return UserConverter.toUserKaKaoFinalSignUpResultDTO(accessToken, refreshToken, savedUser);

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -101,36 +101,6 @@ public class UserCommandServiceImpl implements UserCommandService {
         return userRepository.save(newUser);
     }
 
-
-//    public UserResponseDTO.TokenValidationResultDTO validateToken(String openId) {
-//        // 공개키 가져오기
-//        OIDCPublicKeyResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
-//
-//        // 페이로드 검증 && 서명 검증 후 sub 값 기준으로 회원가입 or 로그인 처리
-//        OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(openId, iss, aud, oidcPublicKeysResponse);
-//        String sub = oidcDecodePayload.getSub();
-//
-//        if (sub == null || sub.isEmpty()) {
-//            return new UserResponseDTO.TokenValidationResultDTO(false, "access token", "refresh token");
-//        }
-//
-//        Optional<Users> userSub = userRepository.findByProviderId(sub);
-//
-//        if (userSub.isPresent()) {
-//            // 사용자가 이미 존재하면 로그인 처리 (토큰 반환)
-//            Users user = userSub.get();
-//
-//            // 액세스 토큰 및 리프레시 토큰 생성
-//            String key = "users:" + user.getId().toString();
-//            String accessToken = generateAccessToken(user.getId(), accessExpTime);
-//            String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
-//
-//            return new UserResponseDTO.TokenValidationResultDTO(true, accessToken, refreshToken);
-//        } else {
-//            return new UserResponseDTO.TokenValidationResultDTO(true, null, null);
-//        }
-//    }
-
     // open id 인증 완료 한 후 1. 로그인을 시키거나, 2. 가입 대기상태의 유저로 임시 회원가입 처리
     @Override
     @Transactional
@@ -179,26 +149,23 @@ public class UserCommandServiceImpl implements UserCommandService {
     // 여기서 일상 카테고리 만들어도 될듯!
     @Override
     @Transactional
-    public UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(String accessToken, UserRequestDTO.SignUpKakaoRequestDTO request) {
-
-//        Long savedUserId = jwtUtils.extractUserId(accessToken);
+    public UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(UserRequestDTO.SignUpKakaoRequestDTO request) {
+        
         Long userId = SecurityUtil.getCurrentUserId();
         Users savedUser = userRepository.findById(userId)
                 .orElseThrow(() -> new ExceptionHandler(ErrorStatus.USER_NOT_FOUND));
 
         // 해당 닉네임을 업데이트
         savedUser.updateNickname(request.getNickname());
-
         // 유저의 상태 pending -> activate 업데이트
         savedUser.updateStatus(UserStatus.ACTIVE);
-
         // 일상 카테고리 생성
         createDefaultCategory(savedUser);
 
         // 액세스 토큰 및 리프레시 토큰 생성
         String key = "users:" + savedUser.getId().toString();
+        String accessToken = generateAccessToken(savedUser.getId(), accessExpTime);
         String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
-
         return UserConverter.toUserKaKaoFinalSignUpResultDTO(accessToken, refreshToken, savedUser);
     }
 

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -98,25 +98,60 @@ public class UserCommandServiceImpl implements UserCommandService {
         return userRepository.save(newUser);
     }
 
+    // open id 인증 완료 한 후 가입 대기상태의 유저로 처리.
     @Override
     @Transactional
-    public UserResponseDTO.UserKaKaoSignUpResultDTO signUpKakao(String openId, UserRequestDTO.SignUpKakaoRequestDTO request) {
+    public UserResponseDTO.UserKaKaoOpenIdResultDTO openIdKakao(String openId) {
 
         // openId를 통해 sub 추출하기
         OIDCPublicKeyResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
         OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(openId, iss, aud, oidcPublicKeysResponse);
         String sub = oidcDecodePayload.getSub();
 
-        Users newUser = UserConverter.toKakaoUsers(request, sub);
-        // 일상 카테고리 생성
-        createDefaultCategory(newUser);
+        // 새로운 유저 생성
+        Users newUser = UserConverter.toKakaoUsers(sub);
+
         // 회원 정보 db에 저장
         Users savedUser = userRepository.save(newUser);
+
+//        // 일상 카테고리 생성
+//        createDefaultCategory(newUser);
         // 액세스 토큰 및 리프레시 토큰 생성
         String key = "users:" + savedUser.getId().toString();
         String accessToken = generateAccessToken(savedUser.getId(), accessExpTime);
         String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
-        return UserConverter.toUserKaKaoSignUpResultDTO(accessToken, refreshToken, savedUser);
+        return UserConverter.toUserKaKaoOpenIdResultDTO(accessToken, refreshToken, savedUser);
+    }
+
+    // Nickname 입력받고 회원 상태 업데이트
+    // 여기서 일상 카테고리 만들어도 될듯!
+    @Override
+    @Transactional
+    public UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(String openId, UserRequestDTO.SignUpKakaoRequestDTO request) {
+        // openId를 통해 sub 추출하기
+        OIDCPublicKeyResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
+        OIDCDecodePayload oidcDecodePayload = oauthOIDCHelper.getPayloadFromIdToken(openId, iss, aud, oidcPublicKeysResponse);
+        String sub = oidcDecodePayload.getSub();
+
+        // openId를 이용해 db에 있는 회원 찾기
+        Users savedUser = userRepository.findByProviderId(sub)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        // 해당 닉네임을 업데이트
+        savedUser.updateNickname(request.getNickname());
+
+        // 유저의 상태 pending -> activate 업데이트
+        savedUser.updateStatus(UserStatus.ACTIVE);
+
+        // 일상 카테고리 생성
+        createDefaultCategory(savedUser);
+
+        // 액세스 토큰 및 리프레시 토큰 생성
+        String key = "users:" + savedUser.getId().toString();
+        String accessToken = generateAccessToken(savedUser.getId(), accessExpTime);
+        String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
+
+        return UserConverter.toUserKaKaoFinalSignUpResultDTO(accessToken, refreshToken, savedUser);
     }
 
     private void createDefaultCategory(Users newUser) {

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -113,11 +113,11 @@ public class UserController {
     )
     @PostMapping("/signup/kakao/nickname")
     public ApiResponse<UserResponseDTO.KaKaoFinalSignUpResultDTO> signUpNickname(
-            @RequestHeader("OpenId") String openId,
+            @RequestHeader("AccessToken") String accessToken,
             @RequestBody UserRequestDTO.SignUpKakaoRequestDTO request
     ) {
         return ApiResponse.onSuccess(
-                userCommandService.kakaoSignUp(openId, request)
+                userCommandService.kakaoSignUp(accessToken, request)
         );
     }
 
@@ -234,20 +234,20 @@ public class UserController {
         return ApiResponse.onSuccess("");
     }
 
-    @Operation(summary = "카카오 로그인 시 회원가입인지 로그인인지 확인하는 API", description =
-                    "header에 'OpenId: {ID token}'형식으로 ID token을 입력해주세요.\n" +
-                    "1. 페이로드 검증 및 서명 검증을 진행합니다.\n" +
-                    "2. 이미 가입한 회원인지 확인합니다.\n\n" +
-                    "회원가입이라면 isRegistered로 false를 반환하고 로그인이라면 isRegistered로 true를 반환함과 동시에 access token과 refresh token을 반환합니다."
-    )
-    @PostMapping("/verificate/kakao")
-    public ApiResponse<UserResponseDTO.TokenValidationResultDTO> validKakaoToken(
-            @RequestHeader("OpenId") String openId
-    ) {
-        return ApiResponse.onSuccess(
-                userCommandService.validateToken(openId)
-        );
-    }
+//    @Operation(summary = "카카오 로그인 시 회원가입인지 로그인인지 확인하는 API", description =
+//                    "header에 'OpenId: {ID token}'형식으로 ID token을 입력해주세요.\n" +
+//                    "1. 페이로드 검증 및 서명 검증을 진행합니다.\n" +
+//                    "2. 이미 가입한 회원인지 확인합니다.\n\n" +
+//                    "회원가입이라면 isRegistered로 false를 반환하고 로그인이라면 isRegistered로 true를 반환함과 동시에 access token과 refresh token을 반환합니다."
+//    )
+//    @PostMapping("/verificate/kakao")
+//    public ApiResponse<UserResponseDTO.TokenValidationResultDTO> validKakaoToken(
+//            @RequestHeader("OpenId") String openId
+//    ) {
+//        return ApiResponse.onSuccess(
+//                userCommandService.validateToken(openId)
+//        );
+//    }
 
     @Operation(summary = "[관리자용] 회원 삭제", description =
             "# 관리자용 API입니다. 삭제할 회원의 ID를 입력해주세요. (사용 주의)"

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -96,6 +96,17 @@ public class UserController {
         return ApiResponse.onSuccess("");
     }
 
+    @Operation(summary = "사용자가 PENDING 상태인지 확인하는 API", description =
+            "# 사용자의 상태 검증 API 입니다."
+    )
+    @GetMapping("/status")
+    public ApiResponse<UserResponseDTO.IsPendingResultDTO> checkIsPending(
+    ) {
+        return ApiResponse.onSuccess(
+                userCommandService.checkIsPending()
+        );
+    }
+
     @Operation(summary = "카카오 openId 검증 API", description =
             "# 카카오 openId 검증 API 입니다. header에 'OpenId: {ID token}'형식으로 ID token을 입력해주세요."
     )

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -109,15 +109,14 @@ public class UserController {
     }
 
     @Operation(summary = "카카오 회원가입 API", description =
-            "# 카카오 회원가입 API 입니다. header에 'OpenId: {ID token}'형식으로 ID token을 입력하고 request body에 닉네임을 입력해주세요."
+            "# 카카오 회원가입 API 입니다. request body에 닉네임을 입력해주세요."
     )
     @PostMapping("/kakao/signup/nickname")
     public ApiResponse<UserResponseDTO.KaKaoFinalSignUpResultDTO> signUpNickname(
-//            @RequestHeader("AccessToken") String accessToken,
             @RequestBody UserRequestDTO.SignUpKakaoRequestDTO request
     ) {
         return ApiResponse.onSuccess(
-                userCommandService.kakaoSignUp(null, request)
+                userCommandService.kakaoSignUp(request)
         );
     }
 

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -3,7 +3,6 @@ package TtattaBackend.ttatta.web.controller;
 import TtattaBackend.ttatta.apiPayload.ApiResponse;
 import TtattaBackend.ttatta.converter.UserConverter;
 import TtattaBackend.ttatta.domain.Users;
-import TtattaBackend.ttatta.oidc.*;
 import TtattaBackend.ttatta.service.UserService.UserCommandService;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserResponseDTO;
@@ -97,35 +96,30 @@ public class UserController {
         return ApiResponse.onSuccess("");
     }
 
-    // 미구현
-    @Operation(summary = "카카오 회원가입", description =
-            "# 카카오 회원가입 API 입니다. header에 'OpenId: {ID token}'형식으로 ID token을 입력하고 request body에 닉네임을 입력해주세요."
+    @Operation(summary = "카카오 openId 검증 API", description =
+            "# 카카오 openId 검증 API 입니다. header에 'OpenId: {ID token}'형식으로 ID token을 입력해주세요."
     )
     @PostMapping("/signup/kakao")
-    public ApiResponse<UserResponseDTO.UserKaKaoSignUpResultDTO> signUpKakao(
+    public ApiResponse<UserResponseDTO.UserKaKaoOpenIdResultDTO> openIdKakao(
+            @RequestHeader("OpenId") String openId
+    ) {
+        return ApiResponse.onSuccess(
+                userCommandService.openIdKakao(openId)
+        );
+    }
+
+    @Operation(summary = "카카오 회원가입 API", description =
+            "# 카카오 회원가입 API 입니다. header에 'OpenId: {ID token}'형식으로 ID token을 입력하고 request body에 닉네임을 입력해주세요."
+    )
+    @PostMapping("/signup/kakao/nickname")
+    public ApiResponse<UserResponseDTO.KaKaoFinalSignUpResultDTO> signUpNickname(
             @RequestHeader("OpenId") String openId,
             @RequestBody UserRequestDTO.SignUpKakaoRequestDTO request
     ) {
         return ApiResponse.onSuccess(
-                userCommandService.signUpKakao(openId, request)
+                userCommandService.kakaoSignUp(openId, request)
         );
     }
-
-    // 미구현
-//    @Operation(summary = "카카오 로그인", description =
-//            "# 카카오 로그인 API 입니다."
-//    )
-//    @PostMapping("/signin/kakao")
-//    public ApiResponse<UserResponseDTO.UserSignInResultDTO> signInKakao(
-//            @RequestBody UserRequestDTO.SignInKakaoRequestDTO request
-//    ) {
-//        Users user = userCommandService.signInKakao(request);
-//        return ApiResponse.onSuccess(
-//                UserConverter.toUserSignInResultDTO(
-//                        user, null, null
-//                )
-//        );
-//    }
 
     @Operation(summary = "회원 정보 조회", description =
             "# 회원 정보 조회 API 입니다."

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -111,13 +111,13 @@ public class UserController {
     @Operation(summary = "카카오 회원가입 API", description =
             "# 카카오 회원가입 API 입니다. header에 'OpenId: {ID token}'형식으로 ID token을 입력하고 request body에 닉네임을 입력해주세요."
     )
-    @PostMapping("/signup/kakao/nickname")
+    @PostMapping("/kakao/signup/nickname")
     public ApiResponse<UserResponseDTO.KaKaoFinalSignUpResultDTO> signUpNickname(
-            @RequestHeader("AccessToken") String accessToken,
+//            @RequestHeader("AccessToken") String accessToken,
             @RequestBody UserRequestDTO.SignUpKakaoRequestDTO request
     ) {
         return ApiResponse.onSuccess(
-                userCommandService.kakaoSignUp(accessToken, request)
+                userCommandService.kakaoSignUp(null, request)
         );
     }
 

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -130,4 +130,12 @@ public class UserResponseDTO {
         LoginType loginType;
         LocalDateTime createdAt;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class IsPendingResultDTO {
+        boolean isPending;
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -110,6 +110,7 @@ public class UserResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UserKaKaoOpenIdResultDTO {
+        Boolean isRegistered;
         String accessToken;
         String refreshToken;
         Long userId;

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -109,7 +109,19 @@ public class UserResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class UserKaKaoSignUpResultDTO {
+    public static class UserKaKaoOpenIdResultDTO {
+        String accessToken;
+        String refreshToken;
+        Long userId;
+        LoginType loginType;
+        LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KaKaoFinalSignUpResultDTO {
         String accessToken;
         String refreshToken;
         Long userId;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #165 

## 📝작업 내용
> 카카오 로그인 회원가입 로직 api 2개로 분리

## 🔎코드 설명
> 사용자 임시저장 : open id만 입력받고, 사용자의 상태를 PENDING 상태로 저장.
> 닉네임과 open id 입력받은 후 provider id를 통해 사용자를 찾고, 닉네임 및 사용자의 상태 PENDING -> ACTIVE로 업데이트

## 💬고민사항 및 리뷰 요구사항 (Optional)
> open Id를 입력받고, 사용자 PENDING상태로 저장할 때 access token, refresh token이 필요한지 모르겠습니다..! 제 생각에는 삭제해도 무방할 것 같은데 혹시 몰라서 남겨둠요..
또 이 방법으로 하면 gender, username, email, password 등등 null로 들어가는 값들이 많은데 이 부분 처리를 어떻게할지 같이 생각해봐주시면 감사하겠습니다!!
--------------------------------------------------
아래 사진설명
처음 2개 :  사용자 임시 저장 성공 & 상태 pending으로 들어감
나중 2개 : open id와 닉네임 입력받은 후 사용자 닉네임 & 상태 업데이트

## 비고 (Optional)
> 
<img width="1710" alt="스크린샷 2025-05-05 오후 10 16 02" src="https://github.com/user-attachments/assets/d5804f22-b96f-4b7f-a7c3-40a1ff0ff830" />
<img width="1710" alt="스크린샷 2025-05-05 오후 10 16 22" src="https://github.com/user-attachments/assets/d1ba9388-e6db-4ee5-9ea7-f8055043c198" />
<img width="1710" alt="스크린샷 2025-05-05 오후 10 17 36" src="https://github.com/user-attachments/assets/a2b3f204-2913-4d53-8d76-1322ce430f0b" />
<img width="1710" alt="스크린샷 2025-05-05 오후 10 17 46" src="https://github.com/user-attachments/assets/c991bdb5-fb0e-4c00-93c5-ffe2263b2639" />

## 최종 사진
>
1. open ID 검증 완료
<img width="1710" alt="openId 검증" src="https://github.com/user-attachments/assets/913f6de3-f1a4-4a64-a511-cb54b31ff44f" />
2. PENDING 상태 확인 -> true
<img width="1710" alt="PENDING상태 검증" src="https://github.com/user-attachments/assets/c76d2f80-c372-42c4-8e5a-280567b5d53a" />
3. 닉네임 입력 후 최종 회원가입
<img width="1710" alt="닉네임 입력 후 최종 회원가입" src="https://github.com/user-attachments/assets/ff394145-a534-4511-a877-a7b49e268d78" />
4. 최종 회원가입 후 PENDING -> false
<img width="1710" alt="최종 회원가입 후 PENDING 검증" src="https://github.com/user-attachments/assets/448c12b8-c6c3-41b6-9f26-467c923f10c3" />


