### PR TITLE
[Fix] JwtUtils에서 발생한 버그 UnsatisfiedDependencyException에러 해결

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/config/RedisConfig.java
+++ b/src/main/java/TtattaBackend/ttatta/config/RedisConfig.java
@@ -2,6 +2,7 @@ package TtattaBackend.ttatta.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
@@ -9,6 +10,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 public class RedisConfig {
 
     @Bean
+    @Primary
     public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(connectionFactory);


### PR DESCRIPTION
## #️⃣연관된 이슈
> #169 

## 📝작업 내용
> JwtUtils에서 발생한 버그 UnsatisfiedDependencyException에러 해결

## 🔎코드 설명
> 에러: 기존에 redisConfig클래스에 정의한 redisTemplate과 stringRedisTemplate 2개가 빈에 등록되어 에러발생
> 에러 해결: redisConfig에서 정의한 redisTemplate에 해당 빈을 기본(우선)으로 선택하는 어노테이션 @Primary적용

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
