### PR TITLE
[Feat] 하루 일기 요약 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,10 @@ dependencies {
 
 	// spring cache
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+	// OPENAI
+	implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.4'
+	implementation 'org.springframework.boot:spring-boot-starter-comcat'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 
 	// OPENAI
 	implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.4'
-	implementation 'org.springframework.boot:spring-boot-starter-comcat'
+	implementation 'org.springframework.boot:spring-boot-starter-tomcat'
 }
 
 tasks.named('test') {

--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -62,7 +62,10 @@ public enum ErrorStatus implements BaseErrorCode {
     CHALLENGE_FULL(HttpStatus.BAD_REQUEST,"CHANLLENGE_6001","챌린지 3개가 이미 생성되어 있어 새로운 챌린지를 생성할 수 없습니다."),
 
     // 일기 사진 관련 응답 7000
-    DIARY_PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "PHOTO_7001", "일기 사진이 없습니다.");
+    DIARY_PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "PHOTO_7001", "일기 사진이 없습니다."),
+
+    // 일기 요약 관련 응답 8000
+    SUMMARY_DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "SUMMARY_8001","일기 요약이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/TtattaBackend/ttatta/config/GptConfig.java
+++ b/src/main/java/TtattaBackend/ttatta/config/GptConfig.java
@@ -1,0 +1,34 @@
+package TtattaBackend.ttatta.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class GptConfig {
+
+    @Value("${openai.secret-key}")
+    private String secretKey;
+
+    @Value("${openai.model}")
+    private String model;
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add((request,body, execution) -> {
+            request.getHeaders().set("Authorization", "Bearer " + secretKey);
+            return execution.execute(request, body);
+        });
+        return restTemplate;
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/converter/SummarizeConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/SummarizeConverter.java
@@ -1,5 +1,7 @@
 package TtattaBackend.ttatta.converter;
 
+import TtattaBackend.ttatta.domain.SummaryDiary;
+import TtattaBackend.ttatta.web.dto.DiarySummaryResponseDTO;
 import TtattaBackend.ttatta.web.dto.Message;
 import TtattaBackend.ttatta.web.dto.ChatGPTResponseDTO;
 
@@ -11,5 +13,12 @@ public class SummarizeConverter {
         Message message = new Message("assistant", summary);
         ChatGPTResponseDTO.Choice choice = new ChatGPTResponseDTO.Choice(0,message);
         return new ChatGPTResponseDTO(Collections.singletonList(choice));
+    }
+
+    public static DiarySummaryResponseDTO.DiarySummaryResultDTO toGetDiarySummaryResponseDTO(SummaryDiary summary) {
+        return DiarySummaryResponseDTO.DiarySummaryResultDTO.builder()
+                .createdAt(summary.getCreatedAt())
+                .summaryDiary(summary.getContent())
+                .build();
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/converter/SummarizeConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/SummarizeConverter.java
@@ -1,0 +1,15 @@
+package TtattaBackend.ttatta.converter;
+
+import TtattaBackend.ttatta.web.dto.Message;
+import TtattaBackend.ttatta.web.dto.ChatGPTResponseDTO;
+
+import java.util.Collections;
+
+public class SummarizeConverter {
+
+    public static ChatGPTResponseDTO toSummarizeResponseDTO(String summary) {
+        Message message = new Message("assistant", summary);
+        ChatGPTResponseDTO.Choice choice = new ChatGPTResponseDTO.Choice(0,message);
+        return new ChatGPTResponseDTO(Collections.singletonList(choice));
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/domain/SummaryDiary.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/SummaryDiary.java
@@ -28,6 +28,9 @@ public class SummaryDiary extends BaseEntity {
     @JoinColumn(name = "user_id")
     private Users users;
 
+    @Column(nullable = false)
+    private String diaryKeyHash;
+
     public void setUser(Users user) {
         if (this.users != null) {
             this.users.getDiariesList().remove(this);

--- a/src/main/java/TtattaBackend/ttatta/domain/SummaryDiary.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/SummaryDiary.java
@@ -42,4 +42,9 @@ public class SummaryDiary extends BaseEntity {
             user.getSummaryDiaryList().add(this);
         }
     }
+
+    public void updateContentAndKeyHash(String content, String diaryKeyHash) {
+        this.content = content;
+        this.diaryKeyHash = diaryKeyHash;
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/domain/SummaryDiary.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/SummaryDiary.java
@@ -1,0 +1,43 @@
+package TtattaBackend.ttatta.domain;
+
+import TtattaBackend.ttatta.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.joda.time.DateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SummaryDiary extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private DateTime date;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Users users;
+
+    public void setUser(Users user) {
+        if (this.users != null) {
+            this.users.getDiariesList().remove(this);
+        }
+
+        this.users = user;
+
+        if (!user.getSummaryDiaryList().contains(this)) {
+            user.getSummaryDiaryList().add(this);
+        }
+    }
+
+}

--- a/src/main/java/TtattaBackend/ttatta/domain/SummaryDiary.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/SummaryDiary.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -19,7 +19,7 @@ public class SummaryDiary extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private DateTime date;
+    private LocalDate date;
 
     @Column(columnDefinition = "TEXT")
     private String content;
@@ -39,5 +39,4 @@ public class SummaryDiary extends BaseEntity {
             user.getSummaryDiaryList().add(this);
         }
     }
-
 }

--- a/src/main/java/TtattaBackend/ttatta/domain/Users.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Users.java
@@ -81,6 +81,9 @@ public class Users extends BaseEntity {
     @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
     private List<Challenges> challengesList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
+    private List<SummaryDiary> summaryDiaryList = new ArrayList<>();
+
     public void encodePassword(String password) {
         this.password = password;
     }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -76,4 +76,9 @@ public interface DiaryRepository extends JpaRepository<Diaries, Long> {
     // 유저별 일기 개수 조회
     @Query("SELECT COUNT(d) FROM Diaries d WHERE d.users = :user")
     long countByUsers(@Param("user") Users user);
+
+    @Query("SELECT d FROM Diaries d WHERE d.users = :user AND d.date BETWEEN :start AND :end")
+    List<Diaries> findAllByUserIdAndDate(@Param("user") Users user,
+                                            @Param("start") LocalDateTime start,
+                                            @Param("end") LocalDateTime end);
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/SummaryDiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/SummaryDiaryRepository.java
@@ -1,0 +1,12 @@
+package TtattaBackend.ttatta.repository;
+
+import TtattaBackend.ttatta.domain.SummaryDiary;
+import TtattaBackend.ttatta.domain.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface SummaryDiaryRepository extends JpaRepository<SummaryDiary, Long> {
+    Optional<SummaryDiary> findByDateAndUsers(LocalDate date, Users users);
+}

--- a/src/main/java/TtattaBackend/ttatta/service/OpenAiService/PromptBuilder.java
+++ b/src/main/java/TtattaBackend/ttatta/service/OpenAiService/PromptBuilder.java
@@ -1,0 +1,26 @@
+package TtattaBackend.ttatta.service.OpenAiService;
+
+import TtattaBackend.ttatta.domain.Diaries;
+
+import java.util.List;
+
+public class PromptBuilder {
+    public static String buildPrompt(List<Diaries> diaries) {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("다음은 사용자의 하루 동안의 일기입니다. 위치, 카테고리, 내용 정보를 바탕으로 오늘 하루를 요약해 주세요. 한 일기의 시작은 '오늘은' 으로 시작해 주세요. " +
+                "또한 만약 하루에 일기가 2개 이상이라면, 각 일기 요약은 엔터로 구분해 주세요." +
+                "'사용자는' 이런 표현은 쓰지 마세요. 중간중간 어울리는 이모티콘은 1~2개 넣어주세요 넣어주세요." +
+                "말투는 ~했어요. 이런식으로 해주세요.\n");
+
+
+        for (Diaries diary : diaries) {
+            prompt.append("- 위치: ").append(diary.getLocationName()).append("\n");
+            prompt.append("  카테고리: ").append(diary.getDiaryCategories()).append("\n");
+            prompt.append("  내용: ").append(diary.getContent()).append("\n\n");
+        }
+
+        prompt.append("이 내용을 종합하여 3~4문장 정도로 자연스럽게 요약해 주세요.");
+
+        return prompt.toString();
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/service/OpenAiService/PromptBuilder.java
+++ b/src/main/java/TtattaBackend/ttatta/service/OpenAiService/PromptBuilder.java
@@ -8,6 +8,8 @@ public class PromptBuilder {
     public static String buildPrompt(List<Diaries> diaries) {
         StringBuilder prompt = new StringBuilder();
         prompt.append("다음은 사용자의 하루 동안의 일기입니다. 위치, 카테고리, 내용 정보를 바탕으로 오늘 하루를 요약해 주세요. 한 일기의 시작은 '오늘은' 으로 시작해 주세요. " +
+                "물론이죠! 이런말을 하지 마세요. 요약만 하시면 됩니다."+
+                "\n을 텍스트로 출력하지 마세요"+
                 "또한 만약 하루에 일기가 2개 이상이라면, 각 일기 요약은 엔터로 구분해 주세요." +
                 "'사용자는' 이런 표현은 쓰지 마세요. 중간중간 어울리는 이모티콘은 1~2개 넣어주세요 넣어주세요." +
                 "말투는 ~했어요. 이런식으로 해주세요.\n");

--- a/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandService.java
@@ -1,0 +1,8 @@
+package TtattaBackend.ttatta.service.OpenAiService;
+
+import TtattaBackend.ttatta.web.dto.ChatGPTRequestDTO;
+import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
+
+public interface SummaryCommandService {
+    public String summarize(DiaryRequestDTO.SummarizeDTO request);
+}

--- a/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandService.java
@@ -6,5 +6,6 @@ import TtattaBackend.ttatta.web.dto.DiarySummaryResponseDTO;
 
 public interface SummaryCommandService {
     public String summarize(DiarySummaryRequestDTO.SummarizeDTO request);
+    public String reSummarize(DiarySummaryRequestDTO.SummarizeDTO request);
     public DiarySummaryResponseDTO.DiarySummaryResultDTO getSummary(DiarySummaryRequestDTO.GetDiarySummaryDTO request);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandService.java
@@ -1,8 +1,10 @@
 package TtattaBackend.ttatta.service.OpenAiService;
 
-import TtattaBackend.ttatta.web.dto.ChatGPTRequestDTO;
-import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
+import TtattaBackend.ttatta.domain.SummaryDiary;
+import TtattaBackend.ttatta.web.dto.DiarySummaryRequestDTO;
+import TtattaBackend.ttatta.web.dto.DiarySummaryResponseDTO;
 
 public interface SummaryCommandService {
-    public String summarize(DiaryRequestDTO.SummarizeDTO request);
+    public String summarize(DiarySummaryRequestDTO.SummarizeDTO request);
+    public DiarySummaryResponseDTO.DiarySummaryResultDTO getSummary(DiarySummaryRequestDTO.GetDiarySummaryDTO request);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandServiceImpl.java
@@ -1,0 +1,57 @@
+package TtattaBackend.ttatta.service.OpenAiService;
+
+import TtattaBackend.ttatta.domain.Diaries;
+import TtattaBackend.ttatta.domain.Users;
+import TtattaBackend.ttatta.repository.DiaryRepository;
+import TtattaBackend.ttatta.repository.UserRepository;
+import TtattaBackend.ttatta.web.dto.ChatGPTRequestDTO;
+import TtattaBackend.ttatta.web.dto.ChatGPTResponseDTO;
+import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SummaryCommandServiceImpl implements SummaryCommandService {
+
+    private final DiaryRepository diaryRepository;
+    private final UserRepository userRepository;
+
+    @Value("${openai.model}")
+    private String model;
+
+    @Value("${openai.api.url}")
+    private String apiUrl;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+
+    @Override
+    public String summarize(DiaryRequestDTO.SummarizeDTO request) {
+        Long userId = request.getUserId();
+        Users user = userRepository.findById(userId).orElse(null);
+        LocalDate  day = request.getDate();
+
+        LocalDateTime todayStart = day.atStartOfDay();
+        LocalDateTime todayEnd = day.atTime(LocalTime.MAX);
+
+        List<Diaries> diaries = diaryRepository.findAllByUserIdAndDate(user, todayStart, todayEnd);
+        String prompt  = PromptBuilder.buildPrompt(diaries);
+
+        ChatGPTRequestDTO gptRequest = new ChatGPTRequestDTO(model, prompt);
+
+        ChatGPTResponseDTO responseDTO = restTemplate.postForObject(apiUrl, gptRequest, ChatGPTResponseDTO.class);
+        return responseDTO.getChoices().get(0).getMessage().getContent();
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandServiceImpl.java
@@ -18,10 +18,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -60,10 +64,18 @@ public class SummaryCommandServiceImpl implements SummaryCommandService {
 
         String content = responseDTO.getChoices().get(0).getMessage().getContent();
 
+        String rawKey = diaries.stream()
+                .map(d -> d.getId() + ":" + d.getUpdatedAt().toString())
+                .sorted()
+                .collect(Collectors.joining(","));
+
+        String diaryKeyHash = generateSHA256(rawKey);
+
         SummaryDiary summaryDiary = SummaryDiary.builder()
                 .date(day)
                 .content(content)
                 .users(user)
+                .diaryKeyHash(diaryKeyHash)
                 .build();
 
         summaryDiaryRepository.save(summaryDiary);
@@ -80,5 +92,19 @@ public class SummaryCommandServiceImpl implements SummaryCommandService {
         SummaryDiary result = summaryDiaryRepository.findByDateAndUsers(day, user)
                 .orElseThrow(() -> new ExceptionHandler(ErrorStatus.SUMMARY_DIARY_NOT_FOUND));
         return SummarizeConverter.toGetDiarySummaryResponseDTO(result);
+    }
+
+    private String generateSHA256(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hash) {
+                hexString.append(String.format("%02x", b));
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 해시 생성 실패", e);
+        }
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandServiceImpl.java
@@ -11,6 +11,7 @@ import TtattaBackend.ttatta.repository.DiaryRepository;
 import TtattaBackend.ttatta.repository.SummaryDiaryRepository;
 import TtattaBackend.ttatta.repository.UserRepository;
 import TtattaBackend.ttatta.web.dto.*;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class SummaryCommandServiceImpl implements SummaryCommandService {
 
     private final DiaryRepository diaryRepository;
@@ -79,6 +81,46 @@ public class SummaryCommandServiceImpl implements SummaryCommandService {
                 .build();
 
         summaryDiaryRepository.save(summaryDiary);
+        return content;
+    }
+
+    @Override
+    public String reSummarize(DiarySummaryRequestDTO.SummarizeDTO request) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Users user = userRepository.findById(userId).orElse(null);
+        LocalDate day = request.getDate();
+
+        LocalDateTime todayStart = day.atStartOfDay();
+        LocalDateTime todayEnd = day.atTime(LocalTime.MAX);
+
+
+        SummaryDiary originalSummaryDiary = summaryDiaryRepository.findByDateAndUsers(day, user)
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus.SUMMARY_DIARY_NOT_FOUND));
+
+        String originalKeyHash = originalSummaryDiary.getDiaryKeyHash();
+
+
+        List<Diaries> diaries = diaryRepository.findAllByUserIdAndDate(user, todayStart, todayEnd);
+
+        String rawKey = diaries.stream()
+                .map(d -> d.getId() + ":" + d.getUpdatedAt().toString())
+                .sorted()
+                .collect(Collectors.joining(","));
+
+        String newKeyHash = generateSHA256(rawKey);
+
+        if (originalKeyHash.equals(newKeyHash)) {
+            return originalSummaryDiary.getContent();
+        }
+
+        String prompt  = PromptBuilder.buildPrompt(diaries);
+        ChatGPTRequestDTO gptRequest = new ChatGPTRequestDTO(model, prompt);
+        ChatGPTResponseDTO responseDTO = restTemplate.postForObject(apiUrl, gptRequest, ChatGPTResponseDTO.class);
+        String content = responseDTO.getChoices().get(0).getMessage().getContent();
+
+        originalSummaryDiary.updateContentAndKeyHash(content, newKeyHash);
+
+        summaryDiaryRepository.save(originalSummaryDiary);
         return content;
     }
 

--- a/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/OpenAiService/SummaryCommandServiceImpl.java
@@ -1,12 +1,16 @@
 package TtattaBackend.ttatta.service.OpenAiService;
 
+import TtattaBackend.ttatta.apiPayload.code.status.ErrorStatus;
+import TtattaBackend.ttatta.apiPayload.exception.handler.ExceptionHandler;
+import TtattaBackend.ttatta.config.security.SecurityUtil;
+import TtattaBackend.ttatta.converter.SummarizeConverter;
 import TtattaBackend.ttatta.domain.Diaries;
+import TtattaBackend.ttatta.domain.SummaryDiary;
 import TtattaBackend.ttatta.domain.Users;
 import TtattaBackend.ttatta.repository.DiaryRepository;
+import TtattaBackend.ttatta.repository.SummaryDiaryRepository;
 import TtattaBackend.ttatta.repository.UserRepository;
-import TtattaBackend.ttatta.web.dto.ChatGPTRequestDTO;
-import TtattaBackend.ttatta.web.dto.ChatGPTResponseDTO;
-import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
+import TtattaBackend.ttatta.web.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,11 +39,13 @@ public class SummaryCommandServiceImpl implements SummaryCommandService {
 
     @Autowired
     private RestTemplate restTemplate;
+    @Autowired
+    private SummaryDiaryRepository summaryDiaryRepository;
 
 
     @Override
-    public String summarize(DiaryRequestDTO.SummarizeDTO request) {
-        Long userId = request.getUserId();
+    public String summarize(DiarySummaryRequestDTO.SummarizeDTO request) {
+        Long userId = SecurityUtil.getCurrentUserId();
         Users user = userRepository.findById(userId).orElse(null);
         LocalDate  day = request.getDate();
 
@@ -50,8 +56,29 @@ public class SummaryCommandServiceImpl implements SummaryCommandService {
         String prompt  = PromptBuilder.buildPrompt(diaries);
 
         ChatGPTRequestDTO gptRequest = new ChatGPTRequestDTO(model, prompt);
-
         ChatGPTResponseDTO responseDTO = restTemplate.postForObject(apiUrl, gptRequest, ChatGPTResponseDTO.class);
-        return responseDTO.getChoices().get(0).getMessage().getContent();
+
+        String content = responseDTO.getChoices().get(0).getMessage().getContent();
+
+        SummaryDiary summaryDiary = SummaryDiary.builder()
+                .date(day)
+                .content(content)
+                .users(user)
+                .build();
+
+        summaryDiaryRepository.save(summaryDiary);
+        return content;
+    }
+
+    @Override
+    public DiarySummaryResponseDTO.DiarySummaryResultDTO getSummary(DiarySummaryRequestDTO.GetDiarySummaryDTO request) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus.USER_NOT_FOUND));
+        LocalDate day = request.getDate();
+
+        SummaryDiary result = summaryDiaryRepository.findByDateAndUsers(day, user)
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus.SUMMARY_DIARY_NOT_FOUND));
+        return SummarizeConverter.toGetDiarySummaryResponseDTO(result);
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -140,7 +140,9 @@ public class UserCommandServiceImpl implements UserCommandService {
             String key = ExistUser.getId().toString();
             String accessToken = generateAccessToken(userSub.get().getId(), accessExpTime);
             String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
-            return UserConverter.toUserKaKaoOpenIdResultDTO(true, accessToken, refreshToken, userSub.get());
+            Boolean isRegistered = ExistUser.getStatus().equals(UserStatus.PENDING) ? false : true;
+
+            return UserConverter.toUserKaKaoOpenIdResultDTO(isRegistered, accessToken, refreshToken, userSub.get());
         }
         // sub가 잘 추출되었지만, 회원 db에 없어 임시 회원가입 처리 해야하는 부분
         else {

--- a/src/main/java/TtattaBackend/ttatta/web/controller/ChatGPTController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/ChatGPTController.java
@@ -1,0 +1,37 @@
+package TtattaBackend.ttatta.web.controller;
+
+
+import TtattaBackend.ttatta.apiPayload.ApiResponse;
+import TtattaBackend.ttatta.converter.SummarizeConverter;
+import TtattaBackend.ttatta.service.OpenAiService.SummaryCommandService;
+import TtattaBackend.ttatta.service.OpenAiService.SummaryCommandServiceImpl;
+import TtattaBackend.ttatta.web.dto.ChatGPTRequestDTO;
+import TtattaBackend.ttatta.web.dto.ChatGPTResponseDTO;
+import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
+import io.github.flashvayne.chatgpt.service.ChatgptService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/gpt")
+public class ChatGPTController {
+    private final ChatgptService chatgptService;
+    private final SummaryCommandServiceImpl summaryCommandServiceImpl;
+    private final SummaryCommandService summaryCommandService;
+
+    public ChatGPTController(ChatgptService chatgptService, SummaryCommandServiceImpl summaryCommandServiceImpl, SummaryCommandService summaryCommandService) {
+        this.chatgptService = chatgptService;
+        this.summaryCommandServiceImpl = summaryCommandServiceImpl;
+        this.summaryCommandService = summaryCommandService;
+    }
+
+    @Operation(
+            summary = "하루 일기 요약 api",
+            description = "하루동안의 일기를 요약하는 api 입니다."
+    )
+    @PostMapping("/chat")
+    public ApiResponse<ChatGPTResponseDTO> summarizeDiary(@RequestBody DiaryRequestDTO.SummarizeDTO request) {
+        String summary = summaryCommandService.summarize(request);
+        return ApiResponse.onSuccess(SummarizeConverter.toSummarizeResponseDTO(summary));
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/web/controller/ChatGPTController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/ChatGPTController.java
@@ -1,15 +1,16 @@
 package TtattaBackend.ttatta.web.controller;
 
-
 import TtattaBackend.ttatta.apiPayload.ApiResponse;
 import TtattaBackend.ttatta.converter.SummarizeConverter;
+import TtattaBackend.ttatta.repository.DiaryRepository;
 import TtattaBackend.ttatta.service.OpenAiService.SummaryCommandService;
 import TtattaBackend.ttatta.service.OpenAiService.SummaryCommandServiceImpl;
-import TtattaBackend.ttatta.web.dto.ChatGPTRequestDTO;
 import TtattaBackend.ttatta.web.dto.ChatGPTResponseDTO;
-import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
+import TtattaBackend.ttatta.web.dto.DiarySummaryRequestDTO;
+import TtattaBackend.ttatta.web.dto.DiarySummaryResponseDTO;
 import io.github.flashvayne.chatgpt.service.ChatgptService;
 import io.swagger.v3.oas.annotations.Operation;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,11 +19,13 @@ public class ChatGPTController {
     private final ChatgptService chatgptService;
     private final SummaryCommandServiceImpl summaryCommandServiceImpl;
     private final SummaryCommandService summaryCommandService;
+    private final DiaryRepository diaryRepository;
 
-    public ChatGPTController(ChatgptService chatgptService, SummaryCommandServiceImpl summaryCommandServiceImpl, SummaryCommandService summaryCommandService) {
+    public ChatGPTController(ChatgptService chatgptService, SummaryCommandServiceImpl summaryCommandServiceImpl, SummaryCommandService summaryCommandService, DiaryRepository diaryRepository) {
         this.chatgptService = chatgptService;
         this.summaryCommandServiceImpl = summaryCommandServiceImpl;
         this.summaryCommandService = summaryCommandService;
+        this.diaryRepository = diaryRepository;
     }
 
     @Operation(
@@ -30,8 +33,18 @@ public class ChatGPTController {
             description = "하루동안의 일기를 요약하는 api 입니다."
     )
     @PostMapping("/chat")
-    public ApiResponse<ChatGPTResponseDTO> summarizeDiary(@RequestBody DiaryRequestDTO.SummarizeDTO request) {
+    public ApiResponse<ChatGPTResponseDTO> summarizeDiary(@RequestBody DiarySummaryRequestDTO.SummarizeDTO request) {
         String summary = summaryCommandService.summarize(request);
         return ApiResponse.onSuccess(SummarizeConverter.toSummarizeResponseDTO(summary));
+    }
+
+
+    @Operation(
+            summary = "하루 일기 요약 조회 api",
+            description = "날짜를 기준으로 해당 날짜의 요약된 일기를 조회하는 api 입니다."
+    )
+    @GetMapping("/get/summary")
+    public ApiResponse<DiarySummaryResponseDTO.DiarySummaryResultDTO> getSummarizeDiary(@ModelAttribute DiarySummaryRequestDTO.GetDiarySummaryDTO request) {
+        return ApiResponse.onSuccess(summaryCommandService.getSummary(request));
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/controller/ChatGPTController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/ChatGPTController.java
@@ -32,10 +32,20 @@ public class ChatGPTController {
             summary = "하루 일기 요약 api",
             description = "하루동안의 일기를 요약하는 api 입니다."
     )
-    @PostMapping("/chat")
+    @PostMapping("/summary")
     public ApiResponse<ChatGPTResponseDTO> summarizeDiary(@RequestBody DiarySummaryRequestDTO.SummarizeDTO request) {
         String summary = summaryCommandService.summarize(request);
         return ApiResponse.onSuccess(SummarizeConverter.toSummarizeResponseDTO(summary));
+    }
+
+    @Operation(
+            summary = "하루 일기 재생성 api",
+            description = "hash값으로 일기 추가 / 삭제 / 수정 감지 후 재생성하는 api 입니다."
+    )
+    @PutMapping("/summary/reSummary")
+    public ApiResponse<String> reSummarizeDiary(@RequestBody DiarySummaryRequestDTO.SummarizeDTO request) {
+        String summary = summaryCommandService.reSummarize(request);
+        return ApiResponse.onSuccess(summary);
     }
 
 
@@ -47,4 +57,5 @@ public class ChatGPTController {
     public ApiResponse<DiarySummaryResponseDTO.DiarySummaryResultDTO> getSummarizeDiary(@ModelAttribute DiarySummaryRequestDTO.GetDiarySummaryDTO request) {
         return ApiResponse.onSuccess(summaryCommandService.getSummary(request));
     }
+
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/ChatGPTRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/ChatGPTRequestDTO.java
@@ -1,0 +1,19 @@
+package TtattaBackend.ttatta.web.dto;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class ChatGPTRequestDTO {
+
+    private String model;
+    private List<Message> messages;
+
+    public ChatGPTRequestDTO(String model, String prompt) {
+        this.model = model;
+        this.messages = new ArrayList<>();
+        this.messages.add(new Message("user", prompt));
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/web/dto/ChatGPTResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/ChatGPTResponseDTO.java
@@ -1,0 +1,22 @@
+package TtattaBackend.ttatta.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatGPTResponseDTO {
+    private List<Choice> choices;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Choice {
+        private int index;
+        private Message message;
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -1,9 +1,9 @@
 package TtattaBackend.ttatta.web.dto;
 
 import TtattaBackend.ttatta.validation.annotation.ExistDiaryCategory;
-import TtattaBackend.ttatta.validation.annotation.ExistUser;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -25,5 +25,11 @@ public class DiaryRequestDTO {
     public static class EditDTO {
         private Optional<String> content = Optional.empty();
         private Optional<Long> diaryCategoryId = Optional.empty();
+    }
+
+    @Getter
+    public static class SummarizeDTO {
+        private Long userId;
+        private LocalDate date;
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryRequestDTO.java
@@ -27,9 +27,4 @@ public class DiaryRequestDTO {
         private Optional<Long> diaryCategoryId = Optional.empty();
     }
 
-    @Getter
-    public static class SummarizeDTO {
-        private Long userId;
-        private LocalDate date;
-    }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiarySummaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiarySummaryRequestDTO.java
@@ -22,5 +22,4 @@ public class DiarySummaryRequestDTO {
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         private LocalDate date;
     }
-
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiarySummaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiarySummaryRequestDTO.java
@@ -1,0 +1,26 @@
+package TtattaBackend.ttatta.web.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+
+public class DiarySummaryRequestDTO {
+
+    @Getter
+    public static class SummarizeDTO {
+        private LocalDate date;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class GetDiarySummaryDTO {
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        private LocalDate date;
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiarySummaryRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiarySummaryRequestDTO.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 
@@ -23,4 +22,5 @@ public class DiarySummaryRequestDTO {
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         private LocalDate date;
     }
+
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiarySummaryResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiarySummaryResponseDTO.java
@@ -1,0 +1,19 @@
+package TtattaBackend.ttatta.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class DiarySummaryResponseDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DiarySummaryResultDTO {
+        LocalDateTime createdAt;
+        String summaryDiary;
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/web/dto/Message.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/Message.java
@@ -1,0 +1,13 @@
+package TtattaBackend.ttatta.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Message {
+    private String role;
+    private String content;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #172 

## 📝작업 내용
> 하루 일기 요약 API 구현
> 요약 일기 날짜 기준 조회 API 구현
> 요약 일기 수정 API 구현

## 🔎코드 설명
> 하루 일기 요약
1. DiaryRequestDTO.SummarizeDTO를 통해 date를 입력받음
2. 해당 유저의 해당 날짜에서 일기 추출 후 PromptBuilder에 입력해 프롬프트를 추출
3. 해당 프롬프트를 ChatGPTRequestDTO의 입력으로 넣음
4. ChatGPTResponseDTO를 반환함
> 요약 일기 날짜 기준 조회
1. date를 입력받고 조회
> 요약 일기 수정
1. 새로운 일기를 작성하기 전 해시값을 먼저 비교하여 일치하면 재생성하지 않고 원래 있던 요약 일기 반환
2. 해시값이 다르다면 새로운 일기를 생성하고 업데이트

## 💬고민사항 및 리뷰 요구사항 (Optional)
>
## 비고 (Optional)
> 하루 일기 요약
<img width="738" height="207" alt="하루 일기 요약" src="https://github.com/user-attachments/assets/83d5c02b-69a3-4c97-a573-8a26e462d231" />
> 요약 일기 조회
<img width="736" height="133" alt="요약 조회" src="https://github.com/user-attachments/assets/cd0bd25b-3dac-4d90-921b-8a6f5b7f6a1f" />
> 일기 변화 없이 재생성
<img width="741" height="102" alt="재생성 (변화 없음)" src="https://github.com/user-attachments/assets/be4d6372-dfdd-4ff2-9197-c286be7687d6" />
> 일기 변화 후 재생성
<img width="740" height="102" alt="재생성 (변화 0)" src="https://github.com/user-attachments/assets/04877191-4d2a-43a1-8ced-89270d8f7d26" />
> 재생성 후 DB 상태 (1개로 유지)
<img width="1287" height="76" alt="재생성해도 DB는 하나" src="https://github.com/user-attachments/assets/964b1bf4-d9e9-42c5-9a20-4ee6ed4dc16f" />
