### PR TITLE
[Feat] 지도 내 일기 반환 시 카테고리 색 포함

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
+++ b/src/main/java/TtattaBackend/ttatta/converter/DiaryConverter.java
@@ -100,6 +100,7 @@ public class DiaryConverter {
                 .date(diaries.getDate())
                 .content(diaries.getContent())
                 .image(imageUrl)
+                .color(diaries.getDiaryCategories().getColor())
                 .firstDiary(diaryList.isFirst())
                 .lastDiary(diaryList.isLast())
                 .build();

--- a/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/DiaryResponseDTO.java
@@ -1,6 +1,7 @@
 package TtattaBackend.ttatta.web.dto;
 
 
+import TtattaBackend.ttatta.domain.enums.CategoryColor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -80,6 +81,7 @@ public class DiaryResponseDTO {
         LocalDateTime date;
         String content;
         String image;
+        CategoryColor color;
         boolean firstDiary;
         boolean lastDiary;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #175 

## 📝작업 내용
> 지도에 일기 반환 시 카테고리 색 포함

## 🔎코드 설명
> 기존에 categoryId를 넘겨주기에, 거기서 color만 get 해서 추가 해줬습니다 :)

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> swagger
<img width="168" alt="스크린샷 2025-07-06 오후 3 19 18" src="https://github.com/user-attachments/assets/031dcc38-0792-4bee-9971-70c8be7b5023" />

