### PR TITLE
[Feat] 암호 (핀) 기능 구현

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -26,6 +26,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_1007", "해당하는 ID가 존재하지 않습니다."),
     ID_NOT_EQUAL(HttpStatus.BAD_REQUEST, "USER_1008", "ID가 일치하지 않습니다."),
     SAME_PASSWORD(HttpStatus.BAD_REQUEST, "USER_1009", "이전 비밀번호와 동일합니다."),
+    PIN_HASH_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_1010", "핀 해시가 존재하지 않습니다."),
 
     // 일기 관련 응답 2000
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_2001", "해당하는 일기가 존재하지 않습니다."),

--- a/src/main/java/TtattaBackend/ttatta/domain/Users.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Users.java
@@ -5,7 +5,6 @@ import TtattaBackend.ttatta.domain.enums.Gender;
 import TtattaBackend.ttatta.domain.enums.LoginType;
 import TtattaBackend.ttatta.domain.enums.UserStatus;
 import TtattaBackend.ttatta.domain.mapping.OwnedItems;
-import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
@@ -32,7 +31,7 @@ public class Users extends BaseEntity {
     @Column
     private String name;
 
-    @Column(length = 8, nullable = true)
+    @Column(length = 8)
     private String nickname;
 
     @Column(length = 15)
@@ -40,6 +39,9 @@ public class Users extends BaseEntity {
 
     @Column(length = 100)
     private String password;
+
+    @Column(length = 60)
+    private String pinHash;
 
     @Enumerated(EnumType.STRING)
     @Column
@@ -97,4 +99,5 @@ public class Users extends BaseEntity {
     }
     public void updatePoint(Long point) {this.point = point;}
     public void updateStatus(UserStatus status) {this.status = status;}
+    public void updatePinHash(String pinHash) {this.pinHash = pinHash;}
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -30,4 +30,8 @@ public interface UserCommandService {
 //    UserResponseDTO.TokenValidationResultDTO validateToken(String openId);
     Long getUserPoint();
     void deleteUserByAdmin(Long userId);
+
+    UserResponseDTO.SetPinResultDTO setPin(UserRequestDTO.SetPinRequestDTO request);
+    UserResponseDTO.ChangePinResultDTO changePin(UserRequestDTO.ChangePinRequestDTO request);
+    UserResponseDTO.GetPinResultDTO getPin();
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -461,5 +461,57 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         userRepository.delete(user);
     }
+
+    @Override
+    public UserResponseDTO.SetPinResultDTO setPin(UserRequestDTO.SetPinRequestDTO request) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        String hashedPin = passwordEncoder.encode(request.getPin());
+        user.updatePinHash(hashedPin);
+
+        userRepository.save(user);
+
+        return UserResponseDTO.SetPinResultDTO.builder()
+                .pinHash(user.getPinHash())
+                .build();
+    }
+
+    @Override
+    public UserResponseDTO.ChangePinResultDTO changePin(UserRequestDTO.ChangePinRequestDTO request) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        if(user.getPinHash() == null || user.getPinHash().isEmpty()) {
+            throw new ExceptionHandler(PIN_HASH_NOT_FOUND);
+        }
+
+        // 새 핀으로 업데이트
+        String hashedNewPin = passwordEncoder.encode(request.getNewPin());
+        user.updatePinHash(hashedNewPin);
+
+        userRepository.save(user);
+
+        return UserResponseDTO.ChangePinResultDTO.builder()
+                .newPinHash(user.getPinHash())
+                .build();
+    }
+
+    @Override
+    public UserResponseDTO.GetPinResultDTO getPin() {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
+
+        if(user.getPinHash() == null || user.getPinHash().isEmpty()) {
+            throw new ExceptionHandler(PIN_HASH_NOT_FOUND);
+        }
+
+        return UserResponseDTO.GetPinResultDTO.builder()
+                .pinHash(user.getPinHash())
+                .build();
+    }
 }
 

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -269,4 +269,38 @@ public class UserController {
         userCommandService.deleteUserByAdmin(userId);
         return ApiResponse.onSuccess("");
     }
+
+
+    @Operation(summary = "암호 (핀번호) 설정", description =
+        "# 암호 (핀번호) 설정 API입니다. 4자리 숫자를 입력해주세요."
+    )
+    @PostMapping("/pin")
+    public ApiResponse<UserResponseDTO.SetPinResultDTO> setPin(
+            @RequestBody UserRequestDTO.SetPinRequestDTO request
+    ) {
+        UserResponseDTO.SetPinResultDTO result = userCommandService.setPin(request);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "암호 (핀번호) 변경", description =
+            "# 암호 (핀번호) 변경 API입니다. 새 암호를 입력해주세요."
+    )
+    @PatchMapping("/pin")
+    public ApiResponse<UserResponseDTO.ChangePinResultDTO> changePin(
+            @RequestBody UserRequestDTO.ChangePinRequestDTO request
+    ) {
+        UserResponseDTO.ChangePinResultDTO result = userCommandService.changePin(request);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "암호 (핀번호) 불러오기", description =
+            "# 암호 (핀번호) 불러오기 API입니다. 현재 설정된 핀을 불러옵니다.\n" +
+                    "BCrypt로 암호화된 핀을 반환하므로 (복호화 불가), BCrypt 라이브러리를 사용해 비교해주세요."
+    )
+    @GetMapping("/pin")
+    public ApiResponse<UserResponseDTO.GetPinResultDTO> getPin() {
+        UserResponseDTO.GetPinResultDTO result = userCommandService.getPin();
+        return ApiResponse.onSuccess(result);
+    }
+
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -1,7 +1,7 @@
 package TtattaBackend.ttatta.web.dto;
 
-import TtattaBackend.ttatta.validation.annotation.ExistUser;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -126,5 +126,25 @@ public class UserRequestDTO {
         private String email;
         @NotBlank(message = "비밀번호는 빈값일 수 없습니다.")
         private String password;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class SetPinRequestDTO {
+        @NotBlank(message = "핀은 빈값일 수 없습니다.")
+        @Pattern(regexp = "^[0-9]{4}$", message = "핀은 4자리 숫자여야 합니다.")
+        private String pin;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ChangePinRequestDTO {
+        @NotBlank(message = "핀은 빈값일 수 없습니다.")
+        @Pattern(regexp = "^[0-9]{4}$", message = "핀은 4자리 숫자여야 합니다.")
+        private String newPin;
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -138,4 +138,28 @@ public class UserResponseDTO {
     public static class IsPendingResultDTO {
         boolean isPending;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SetPinResultDTO {
+        String pinHash;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChangePinResultDTO {
+        String newPinHash;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetPinResultDTO {
+        String pinHash;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#174 

## 📝작업 내용
암호 (핀) 기능을 구현했습니다.
이에 따라 User 엔티티에 pin_hash 필드를 추가했습니다

<img width="300" height="617" alt="image" src="https://github.com/user-attachments/assets/dea97cda-2144-42c3-aee6-278deca1cd34" />


## 🔎코드 설명
<img width="400" height="252" alt="image" src="https://github.com/user-attachments/assets/347028f1-5ac4-4147-a867-57054ef79430" />

- 암호 설정 (POST) : 4자리 숫자를 입력받으면 이를 해시 처리하여 문자열로 DB에 저장합니다.

<img width="400" height="245" alt="image" src="https://github.com/user-attachments/assets/75bf75c0-b469-4f49-ab97-e47251937fbe" />

- 암호 변경 (PATCH) : 암호 설정과 동일하게 4자리 숫자를 입력받아 해시 처리하고, DB를 수정합니다.

<img width="400" height="244" alt="image" src="https://github.com/user-attachments/assets/41de7558-9768-466a-be9c-572eb2f86168" />

- 암호 불러오기 (GET) : 해당 유저의 해시 암호값을 반환합니다.

프론트에서는 반드시 **BCrypt** 라이브러리를 사용하여, BCrypt.checkpw(기존값, 변경값)의 형식으로 일치 여부를 확인해야함
(BCrypt 방식은 복호화가 불가능하고 보안상의 이슈로 원본값 전송 불가)

## 💬고민사항 및 리뷰 요구사항 (Optional)
x

## 비고 (Optional)
x
