### PR TITLE
[Feat] 회원탈퇴 사유 저장 구현

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/TtattaBackend/ttatta/apiPayload/code/status/ErrorStatus.java
@@ -27,6 +27,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ID_NOT_EQUAL(HttpStatus.BAD_REQUEST, "USER_1008", "ID가 일치하지 않습니다."),
     SAME_PASSWORD(HttpStatus.BAD_REQUEST, "USER_1009", "이전 비밀번호와 동일합니다."),
     PIN_HASH_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_1010", "핀 해시가 존재하지 않습니다."),
+    USERNAME_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "USER_1011", "이미 존재하는 아이디입니다."),
 
     // 일기 관련 응답 2000
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_2001", "해당하는 일기가 존재하지 않습니다."),

--- a/src/main/java/TtattaBackend/ttatta/domain/UsersWithdrawals.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/UsersWithdrawals.java
@@ -1,0 +1,38 @@
+package TtattaBackend.ttatta.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UsersWithdrawals {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String reason;
+
+    @Column(nullable = false)
+    private LocalDateTime withdrawnAt;
+
+    @Column(nullable = false)
+    private Integer activeDays;
+
+    @Column(nullable = false)
+    private Integer totalDiary;
+
+    // 탈퇴 정보 설정
+    public void setWithdrawalInfo(String reason, Integer activeDays, Integer totalDiary) {
+        this.reason = reason;
+        this.withdrawnAt = LocalDateTime.now();
+        this.activeDays = activeDays;
+        this.totalDiary = totalDiary;
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/repository/UserWithdrawalRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/UserWithdrawalRepository.java
@@ -1,0 +1,7 @@
+package TtattaBackend.ttatta.repository;
+
+import TtattaBackend.ttatta.domain.UsersWithdrawals;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserWithdrawalRepository extends JpaRepository<UsersWithdrawals, Long> {
+}

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -18,7 +18,7 @@ public interface UserCommandService {
 //    Users signInKakao(UserRequestDTO.SignInKakaoRequestDTO request);    // 미구현
     UserResponseDTO.UserInfoResultDTO getUserInfo();
     Users editUserInfo(UserRequestDTO.EditRequestDTO request);
-    void deleteUser();
+    UserResponseDTO.UserDeleteResultDTO deleteUser(UserRequestDTO.DeleteRequestDTO request);
     void sendMail(String email);
     void sendVerificationMailSignUp(UserRequestDTO.SendVerificationMailSignUpRequestDTO request);
     void checkVerificationCode(UserRequestDTO.CheckVerificationCodeRequestDTO request);

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -8,12 +8,14 @@ import TtattaBackend.ttatta.converter.DiaryCategoryConverter;
 import TtattaBackend.ttatta.converter.UserConverter;
 import TtattaBackend.ttatta.domain.DiaryCategories;
 import TtattaBackend.ttatta.domain.Users;
+import TtattaBackend.ttatta.domain.UsersWithdrawals;
 import TtattaBackend.ttatta.domain.enums.*;
 import TtattaBackend.ttatta.jwt.JwtUtils;
 import TtattaBackend.ttatta.oidc.*;
 import TtattaBackend.ttatta.repository.DiaryCategoryRepository;
 import TtattaBackend.ttatta.repository.DiaryRepository;
 import TtattaBackend.ttatta.repository.UserRepository;
+import TtattaBackend.ttatta.repository.UserWithdrawalRepository;
 import TtattaBackend.ttatta.web.dto.DiaryCategoryRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserResponseDTO;
@@ -34,7 +36,9 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -63,6 +67,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final UserRepository userRepository;
     private final DiaryRepository diaryRepository;
     private final DiaryCategoryRepository diaryCategoryRepository;
+    private final UserWithdrawalRepository userWithdrawalRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtUtils jwtUtils;
@@ -287,11 +292,36 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public void deleteUser() {
+    @Transactional
+    public UserResponseDTO.UserDeleteResultDTO deleteUser(UserRequestDTO.DeleteRequestDTO request) {
         Users user = userRepository.findById(SecurityUtil.getCurrentUserId())
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
 
+        LocalDateTime withdrawnAt = LocalDateTime.now();    // 탈퇴일시
+        Integer totalDiary = Math.toIntExact(diaryRepository.countByUsers(user));   // 전체 일기 수
+
+        // 가입일 - 탈퇴일 활동일수 (일수로)
+        LocalDate joined = user.getCreatedAt().toLocalDate();
+        int activeDays = (int) ChronoUnit.DAYS.between(joined, withdrawnAt.toLocalDate()) + 1;
+
+        // 탈퇴 정보 저장
+        UsersWithdrawals withdrawal = UsersWithdrawals.builder()
+                .reason(request.getReason())
+                .withdrawnAt(withdrawnAt)
+                .activeDays(activeDays)
+                .totalDiary(totalDiary)
+                .build();
+        UsersWithdrawals savedWithdrawal = userWithdrawalRepository.save(withdrawal);
+
         userRepository.delete(user);
+
+        return UserResponseDTO.UserDeleteResultDTO.builder()
+                .id(savedWithdrawal.getId())
+                .reason(savedWithdrawal.getReason())
+                .withdrawnAt(savedWithdrawal.getWithdrawnAt())
+                .activeDays(savedWithdrawal.getActiveDays())
+                .totalDiary(savedWithdrawal.getTotalDiary())
+                .build();
     }
 
     @Override

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -99,6 +99,12 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Override
     @Transactional // ???
     public Users signUp(UserRequestDTO.SignUpRequestDTO request) {
+        // 아이디 중복 확인
+        IsAvailable usernameAvailable = verifyUsernameOverlap(request.getUsername());
+        if (usernameAvailable.equals(IsAvailable.UNAVAILABLE)) {
+            throw new ExceptionHandler(ErrorStatus.USERNAME_ALREADY_EXIST);
+        }
+
         Users newUser = UserConverter.toUsers(request);
         newUser.encodePassword(passwordEncoder.encode(request.getPassword()));
         // 일상 카테고리 생성

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -160,9 +160,11 @@ public class UserController {
             "# 회원 탈퇴 API 입니다."
     )
     @DeleteMapping("")
-    public ApiResponse<Object> deleteUser() {
-        userCommandService.deleteUser();
-        return ApiResponse.onSuccess("");
+    public ApiResponse<UserResponseDTO.UserDeleteResultDTO> deleteUser(
+            @RequestBody UserRequestDTO.DeleteRequestDTO request
+    ) {
+        UserResponseDTO.UserDeleteResultDTO result = userCommandService.deleteUser(request);
+        return ApiResponse.onSuccess(result);
     }
 
 

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserRequestDTO.java
@@ -77,6 +77,15 @@ public class UserRequestDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
+    public static class DeleteRequestDTO {
+        @NotBlank(message = "탈퇴 사유는 빈값일 수 없습니다.")
+        private String reason;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class SendVerificationMailSignUpRequestDTO {
         @NotBlank(message = "이메일은 빈값일 수 없습니다.")
         private String email;

--- a/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
+++ b/src/main/java/TtattaBackend/ttatta/web/dto/UserResponseDTO.java
@@ -90,6 +90,18 @@ public class UserResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class UserDeleteResultDTO {
+        Long id;
+        String reason;
+        LocalDateTime withdrawnAt;
+        Integer activeDays;
+        Integer totalDiary;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class FindIdResultDTO {
         String name;
         String id;


### PR DESCRIPTION
## #️⃣연관된 이슈
#181 

## 📝작업 내용
회원탈퇴 과정에서 탈퇴 이유를 저장합니다.

## 🔎코드 설명
<img width="335" height="144" alt="image" src="https://github.com/user-attachments/assets/111840ea-cf1f-4298-bd5e-b0e58449f181" />

독립된 별도의 테이블을 만들었습니다.
여기에 탈퇴 사유와 시점, 작성한 일기수, 활동일의 정보가 저장됩니다.

<img width="1101" height="89" alt="image" src="https://github.com/user-attachments/assets/5633352c-e157-4990-8ad0-66b28f02ef01" />

이렇게 DB에 저장됩니다.


+ 추가로 회원가입시에 아이디 중복 확인하는 로직을 추가했습니다.
(이미 존재하는 방식이라 가져왔습니다.)

## 💬고민사항 및 리뷰 요구사항 (Optional)
User와 연관관계없이 독립된 테이블입니다.
단순 정보 저장 용도임을 알아주시면 되겠습니다.

## 비고 (Optional)
x
