### PR TITLE
[Fix] 하루 요약 알림 off후 on API 호출 시 알림 상태가 on으로 업데이트 되지 않는 문제 해결

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/service/AlarmService/AlarmCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/AlarmService/AlarmCommandServiceImpl.java
@@ -317,6 +317,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
     }
 
     @Override
+    @Transactional
     public AlarmResponseDTO.DailySummaryAlarmOnResponseDTO sendDailySummaryPushAlarmNotificationByFcm() {
         Long userId = SecurityUtil.getCurrentUserId();
         Users getUser = userRepository.findById(userId)


### PR DESCRIPTION
## #️⃣연관된 이슈
> #210

## 📝작업 내용
> 하루 요약 알림 off후 on API 호출 시 알림 상태가 on으로 업데이트 되지 않는 문제 해결

## 🔎코드 설명
> AlarmCommandServiceImpl클래스의 sendDailySummaryPushAlarmNotificationByFcm메소드에서 entity객체의 변수 업데이트 후 플러시 및 커밋이 안되어 DB에 반영되지 않아 @Transactionl을 메소드에 붙여서 해결

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
