### PR TITLE
[Fix] 챌린지 리마인드 알림 on API에서 Challenges 객체 단일조회 메소드에서 여러 객체가 조회되는 오류 해결

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/repository/ChallengeRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/ChallengeRepository.java
@@ -24,6 +24,6 @@ public interface ChallengeRepository extends JpaRepository<Challenges, Long> {
             "ORDER BY c.createdAt DESC " +
             "LIMIT 5")
     List<Challenges> findTop5ByUserAndIsCompletedFalseExcludeTodayOrderByCreatedAtDesc(@Param("user") Users user);
-
     Challenges findByUsers(Users getUser);
+    boolean existsByUsersAndIsCompletedFalseAndCreatedAtBetween(Users users, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/TtattaBackend/ttatta/service/AlarmService/AlarmCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/AlarmService/AlarmCommandServiceImpl.java
@@ -253,7 +253,7 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
         } else {
             getChallengeRemindAlarm.updateIsActive(IsActive.ON);
         }
-        if (getChallengeRemindAlarm.getAlaramTime().isAfter(LocalTime.now()) && challengeRepository.findByUsers(getUser) != null) { // 현재 시간보다 이전 알림 시간은 예약하지 않음, 챌린지가 없으면 알림 예약 x
+        if (getChallengeRemindAlarm.getAlaramTime().isAfter(LocalTime.now()) && challengeRepository.existsByUsersAndIsCompletedFalseAndCreatedAtBetween(getUser, LocalDate.now().atStartOfDay(), LocalDate.now().plusDays(1).atStartOfDay())) { // 현재 시간보다 이전 알림 시간은 예약하지 않음, 챌린지가 없으면 알림 예약 x
             LocalDateTime ALARM_TIME = getAlarmLocalDateTime(getChallengeRemindAlarm.getAlaramTime());
             reserveSendPushNotificationByFcm(ALARM_TIME, getUser, AlaramType.CHALLENGE_REMIND, challengeRemindAlarmScheduledTasks);
         }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandService.java
@@ -34,5 +34,5 @@ public interface UserCommandService {
     UserResponseDTO.SetPinResultDTO setPin(UserRequestDTO.SetPinRequestDTO request);
     UserResponseDTO.ChangePinResultDTO changePin(UserRequestDTO.ChangePinRequestDTO request);
     UserResponseDTO.GetPinResultDTO getPin();
-    UserResponseDTO.DeletePinResultDTO deletePin();
+    void deletePin();
 }

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -553,7 +553,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public UserResponseDTO.DeletePinResultDTO deletePin() {
+    public void deletePin() {
         Long userId = SecurityUtil.getCurrentUserId();
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExceptionHandler(USER_NOT_FOUND));
@@ -564,9 +564,6 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         user.updatePinHash(null);
         userRepository.save(user);
-
-        return UserResponseDTO.DeletePinResultDTO.builder()
-                .build();
     }
 }
 

--- a/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
+++ b/src/main/java/TtattaBackend/ttatta/web/controller/UserController.java
@@ -309,9 +309,9 @@ public class UserController {
             "# 암호 (핀번호) 삭제 API입니다."
     )
     @DeleteMapping("/pin")
-    public ApiResponse<UserResponseDTO.DeletePinResultDTO> deletePin() {
-        UserResponseDTO.DeletePinResultDTO result = userCommandService.deletePin();
-        return ApiResponse.onSuccess(result);
+    public ApiResponse<?> deletePin() {
+        userCommandService.deletePin();
+        return ApiResponse.onSuccess("");
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #212 

## 📝작업 내용
> 챌린지 리마인드 알림 on API에서 Challenges 객체 단일조회 메소드에서 여러 객체가 조회되는 오류 해결

## 🔎코드 설명
> ChallengeRepository.java에서 existsByUsersAndIsCompletedFalseAndCreatedAtBetween메소드로 대체하여 해당 조건에 따른 존재여부만 파악

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
