### PR TITLE
[Feat] 위치기반 리마인드 알림 시 해당 일기와 해당 일기 기준 반경 500m 내의 일기들에 한달(30일) 쿨타임 부여

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
+++ b/src/main/java/TtattaBackend/ttatta/domain/Diaries.java
@@ -87,6 +87,8 @@ public class Diaries extends BaseEntity {
     @Column(name = "enc_ver", nullable = false)
     private short encVer = 1;
 
+    @Column(nullable = false)
+    private int memoryDiaryAlarmCoolTime;
 
     public void setUsers(Users users) {
         // 기존에 이미 등록되어 있던 관계를 제거
@@ -122,4 +124,7 @@ public class Diaries extends BaseEntity {
         this.content = content;
     }
 
+    public void updateMemoryDiaryAlarmCoolTime(int memoryDiaryAlarmCoolTime) {
+        this.memoryDiaryAlarmCoolTime = memoryDiaryAlarmCoolTime;
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -6,6 +6,7 @@ import TtattaBackend.ttatta.domain.Users;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.security.core.parameters.P;
@@ -178,4 +179,8 @@ public interface DiaryRepository extends JpaRepository<Diaries, Long> {
     );
 
     List<Diaries> findAllByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    @Modifying
+    @Query("UPDATE Diaries d SET d.memoryDiaryAlarmCoolTime = d.memoryDiaryAlarmCoolTime - 1 WHERE d.memoryDiaryAlarmCoolTime > 0")
+    void decreaseCoolTimeOnMemoryDiaries();
 }

--- a/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
+++ b/src/main/java/TtattaBackend/ttatta/repository/DiaryRepository.java
@@ -170,6 +170,7 @@ public interface DiaryRepository extends JpaRepository<Diaries, Long> {
           d.location
         )
         AND d.user_id = :userId
+        AND d.memory_diary_alarm_cool_time = 0
         """, nativeQuery = true)
     List<Diaries> findNearDiariesCandidates(
             @Param("wkt") String wkt,

--- a/src/main/java/TtattaBackend/ttatta/service/AlarmService/AlarmCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/AlarmService/AlarmCommandServiceImpl.java
@@ -421,12 +421,6 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
     public void decreaseMemoryDiaryAlarmCoolTime() {
-        List<Diaries> diariesList = diaryRepository.findAll();
-        for (Diaries diary : diariesList) {
-            int currentCoolTime = diary.getMemoryDiaryAlarmCoolTime();
-            if (currentCoolTime > 0) {
-                diary.updateMemoryDiaryAlarmCoolTime(currentCoolTime - 1);
-            }
-        }
+        diaryRepository.decreaseCoolTimeOnMemoryDiaries();
     }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/AlarmService/AlarmCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/AlarmService/AlarmCommandServiceImpl.java
@@ -416,4 +416,17 @@ public class AlarmCommandServiceImpl implements AlarmCommandService {
                 getDailySummaryAlarm
         );
     }
+
+    // 매일 자정에 위치기반 알림 쿨타임 차감 on 알림들 예약하는 메소드 실행
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void decreaseMemoryDiaryAlarmCoolTime() {
+        List<Diaries> diariesList = diaryRepository.findAll();
+        for (Diaries diary : diariesList) {
+            int currentCoolTime = diary.getMemoryDiaryAlarmCoolTime();
+            if (currentCoolTime > 0) {
+                diary.updateMemoryDiaryAlarmCoolTime(currentCoolTime - 1);
+            }
+        }
+    }
 }

--- a/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiaryService/DiaryQueryServiceImpl.java
@@ -17,6 +17,7 @@ import TtattaBackend.ttatta.security.DecryptedLocation;
 import TtattaBackend.ttatta.security.EnvelopeCryptoService;
 import TtattaBackend.ttatta.web.dto.DiaryRequestDTO;
 import TtattaBackend.ttatta.web.dto.DiaryResponseDTO;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
@@ -52,6 +53,7 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
     private static final int SEARCH_RANGE = 100;    // 검색 범위 설정 (100m)
     private final GeometryFactory geometryFactory;
     private final EnvelopeCryptoService envelopeCryptoService;
+    private static final int MEMORY_DIARY_COOL_TIME_AREA_RANGE = 500;    // 검색 범위 설정 (100m)
 
     @Override
     public DiaryResponseDTO.FootprintDiaryListDTO getFootprintDiaryList(Long diaryCategoryId, DiaryRequestDTO.ViewOnMapDTO request){
@@ -269,6 +271,7 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
     }
 
     @Override
+    @Transactional
     public void findRemindDiary(DiaryRequestDTO.RemindDTO request) {
         Long userId = SecurityUtil.getCurrentUserId();
         Users user = userRepository.findById(userId).orElseThrow(
@@ -310,6 +313,8 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
                 ));
         System.out.println("nearestDiaries real Candidates: " + nearestDiary.get().getId());
 
+        // 반환한 일기(nearestDiary) 주변 500m반경 내의 일기들의 위치기반 추억 알림 쿨타임을 한달(30일)로 설정
+        setMemoryDiaryAlarmCoolTime(userId, nearestDiary.get(), 30);
 
         // 시간 계산
         long days = ChronoUnit.DAYS.between(nearestDiary.get().getDate().toLocalDate(), LocalDate.now());
@@ -329,6 +334,37 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
 
         // 알림 보내기
         alarmCommandService.sendMemoryDiaryAlarm(user, timeMessage, nearestDiary.get().getId());
+    }
+
+    private void setMemoryDiaryAlarmCoolTime(Long userId, Diaries currentDiary, int coolTime) {
+        // 1. 일기 주변 500m 반경 내 일기들 조회
+        Decoded decoded = tryDecode(currentDiary, userId);
+        Double currentLatitude = decoded.lat();
+        Double currentLongitude = decoded.lng();
+        List<Pt> square = buildSquare(currentLatitude, currentLongitude, 600.0);
+        String wkt = toPolygonWKT(square);
+        List<Diaries> nearDiariesCandidates = diaryRepository.findNearDiariesCandidates(wkt, userId);
+        // 서버 로그에서 확인하기 위함
+        for (Diaries diary : nearDiariesCandidates) {
+            System.out.println("nearDiariesCandidates id: " + diary.getId());
+        }
+
+        if (nearDiariesCandidates.isEmpty()) {    // 검색 범위 내에 일기가 없는 경우
+            return;
+        }
+
+        // 검색 범위(정사각형) 내 복호화를 진행하고, 실제로 일기 위도 경도에서 100m 원 안에 있는 일기 중 가장 최신 일기 반환
+        // 영 이상하면 getDate -> getCreatedAt으로 수정 (마지막줄)
+        List<Diaries> nearestDiary = nearDiariesCandidates
+                .parallelStream()
+                .map(d -> tryDecode(d, userId))   // Decoded(diaries, lat, lng, ok)
+                .filter(Decoded::ok)
+                .filter(dd -> haversineMeters(currentLatitude, currentLongitude, dd.lat(), dd.lng()) <= MEMORY_DIARY_COOL_TIME_AREA_RANGE)
+                .map(Decoded::diary)
+                .toList();
+
+        // 2. 각 엔티티 값 수정 -> 트랜잭션 커밋 때 DB에 UPDATE됨(Managed라면)
+        nearestDiary.forEach(d -> d.updateMemoryDiaryAlarmCoolTime(coolTime));
     }
 
     @Override


### PR DESCRIPTION
## #️⃣연관된 이슈
> #243

## 📝작업 내용
> 위치기반 리마인드 알림 시 해당 일기와 해당 일기 기준 반경 500m 내의 일기들에 한달(30일) 쿨타임 부여
> 위치기반 리마인드 알림을 보내기 위해 주변 일기를 탐색할때 쿨타임이 있는 일기는 제외

## 🔎코드 설명
> Diaries테이블에 int타입의 쿨타임 컬럼(memory_diary_alarm_cool_time) 추가하여 알림이 왔을때 영역안에 있는 일기들에 대해 30(일) 쿨타임 부여함
> @Scheduled로 매일 자정에 쿨타임이 0이 아닌 일기들에 대해 1(일)씩 차감함.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
