### PR TITLE
[Fix] 관리자페이지(위치정보시스템) 로그인 실패 문제 해결

### DIFF
--- a/src/main/java/TtattaBackend/ttatta/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/TtattaBackend/ttatta/config/security/JwtAuthenticationFilter.java
@@ -111,7 +111,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // 타임리프 페이지 인가 처리
             String accessToken = resolveToken(request);
             jwtUtils.validateToken(accessToken); // 토큰 검증
-            jwtUtils.isTokenBlacklisted(authHeader); // 🚨 블랙리스트 확인
+            jwtUtils.isTokenBlacklisted(accessToken); // 🚨 블랙리스트 확인
         } catch (Exception e) {
             Gson gson = new Gson();
             String json = "";
@@ -163,9 +163,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private String resolveToken(HttpServletRequest request) {
         // 1) Authorization 헤더: Bearer
         String authHeader = request.getHeader(jwtHeader);
-        if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            checkAuthorizationHeader(authHeader);   // header 가 올바른 형식인지 체크
-            return JwtUtils.getTokenFromHeader(authHeader);
+        if (authHeader != null) {
+            if (authHeader.startsWith("Bearer ")){
+                checkAuthorizationHeader(authHeader);   // header 가 올바른 형식인지 체크
+                return JwtUtils.getTokenFromHeader(authHeader);
+            }
         }
         // 2) 쿠키: ACCESS_TOKEN
         if (request.getCookies() != null) {

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -258,6 +258,7 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     @Override
     public void logout(String accessToken) {
+        String accessTokenWithoutBearer = accessToken.split(" ")[1];
         // 로그아웃시킬 회원의 refresh token redis에서 삭제
         Long userId = SecurityUtil.getCurrentUserId();
         String key = "users:" + userId.toString();
@@ -266,7 +267,7 @@ public class UserCommandServiceImpl implements UserCommandService {
         // 로그아웃시킬 회원의 access token redis의 블랙리스트로 저장
         key = "blackList:" + userId.toString();
         long tokenRemainTimeSecond = jwtUtils.tokenRemainTimeSecond(accessToken);
-        redisTemplate.opsForValue().set(key, accessToken, tokenRemainTimeSecond, TimeUnit.SECONDS);
+        redisTemplate.opsForValue().set(key, accessTokenWithoutBearer, tokenRemainTimeSecond, TimeUnit.SECONDS);
 
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #246

## 📝작업 내용
> 작업한 내용을 작성해주세요.
관리자페이지(위치정보시스템) 로그인 실패 문제 해결

## 🔎코드 설명
> 코드에 대한 설명을 작성해주세요.
- 오류 내용: 'Cannot invoke String.equals(Object) because 'accessToken' is null'
- 오류 원인: JwtAuthenticationFilter에서 블랙리스트 체크 시 isTokenBlacklisted()에 Authorization 헤더 값을 전달하고 있었음. 쿠키 기반 인증( resolveToken() )으로 accessToken을 가져오는 경우 authHeader가 null이 되어 NPE 발생 → 인증 실패
- 오류 해결: resolveToken()으로 얻은 accessToken을 사용하도록 변경하여 isTokenBlacklisted() 호출 시 null 전달이 발생하지 않도록 수정

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x