### PR TITLE
[Feat] 일반가입 & 카카오가입 시 디스코드 알림 웹훅 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ application.yml
 
 ### firebase key ###
 ttatta-6a48f-firebase-adminsdk-fbsvc-9e3ca02822.json
+firebase.json

--- a/src/main/java/TtattaBackend/ttatta/service/DiscordService.java
+++ b/src/main/java/TtattaBackend/ttatta/service/DiscordService.java
@@ -1,0 +1,37 @@
+package TtattaBackend.ttatta.service;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class DiscordService {
+
+    @Value("${discord.webhook.url}")
+    private String webhookUrl;
+
+    private final RestTemplate restTemplate;
+
+    public DiscordService(RestTemplateBuilder restTemplateBuilder) {
+        this.restTemplate = restTemplateBuilder
+                .connectTimeout(Duration.ofSeconds(3)) // 연결 자체를 맺는데 걸리는 최대 시간 (3초)
+                .readTimeout(Duration.ofSeconds(3))    // 연결 후 응답 데이터를 읽는데 걸리는 최대 시간 (3초)
+                .build();
+    }
+
+    public void sendSignUpNotification(String username, String type) {
+        Map<String, String> message = new HashMap<>();
+        message.put("content", "새로운 회원 " + username + "님이 " + type + " 가입하셨습니다!");
+
+        try {
+            restTemplate.postForEntity(webhookUrl, message, String.class);
+        } catch (Exception e) {
+            // 예외 처리 (로그 기록 등)
+            System.err.println("Discord 알림 전송 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/TtattaBackend/ttatta/service/UserService/UserCommandServiceImpl.java
@@ -17,6 +17,7 @@ import TtattaBackend.ttatta.repository.DiaryCategoryRepository;
 import TtattaBackend.ttatta.repository.DiaryRepository;
 import TtattaBackend.ttatta.repository.UserRepository;
 import TtattaBackend.ttatta.repository.UserWithdrawalRepository;
+import TtattaBackend.ttatta.service.DiscordService;
 import TtattaBackend.ttatta.web.dto.DiaryCategoryRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserRequestDTO;
 import TtattaBackend.ttatta.web.dto.UserResponseDTO;
@@ -80,6 +81,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final KakaoOauthHelper kakaoOauthHelper;
     private final JwtOIDCProvider jwtOIDCProvider;
     private final AmazonS3Manager s3Manager;
+    private final DiscordService discordService;
 
     @Override
     public Users createTestUser() {
@@ -112,7 +114,13 @@ public class UserCommandServiceImpl implements UserCommandService {
         newUser.encodePassword(passwordEncoder.encode(request.getPassword()));
         // 일상 카테고리 생성
         createDefaultCategory(newUser);
-        return userRepository.save(newUser);
+
+        Users savedUser = userRepository.save(newUser);
+
+        // 디스코드 알림 전송
+        discordService.sendSignUpNotification(savedUser.getUsername(), "일반");
+
+        return savedUser;
     }
 
     @Override
@@ -179,7 +187,7 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Override
     @Transactional
     public UserResponseDTO.KaKaoFinalSignUpResultDTO kakaoSignUp(UserRequestDTO.SignUpKakaoRequestDTO request) {
-        
+
         Long userId = SecurityUtil.getCurrentUserId();
         Users savedUser = userRepository.findById(userId)
                 .orElseThrow(() -> new ExceptionHandler(ErrorStatus.USER_NOT_FOUND));
@@ -195,6 +203,10 @@ public class UserCommandServiceImpl implements UserCommandService {
         String key = "users:" + savedUser.getId().toString();
         String accessToken = generateAccessToken(savedUser.getId(), savedUser.getRole(), accessExpTime);
         String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
+
+        // 디스코드 알림 전송
+        discordService.sendSignUpNotification(savedUser.getUsername(), "카카오");
+
         return UserConverter.toUserKaKaoFinalSignUpResultDTO(accessToken, refreshToken, savedUser);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #254 

## 📝작업 내용
- Discord 웹훅을 활용한 신규 회원가입 알림 전송 기능 추가
- UserCommandService의 일반 회원가입(signUp) 및 카카오 연동 회원가입(kakaoSignUp) 완료 시점에 알림 연동
- 디스코드 알림 전송 실패가 회원가입 트랜잭션에 영향을 주지 않도록 예외 처리

## 🔎코드 설명
- DiscordService.java: RestTemplate을 사용하여 디스코드 웹훅 URL로 JSON 형태의 메세지를 POST 요청하는 전용 서비스 객체를 구현했습니다.
- 타임아웃 설정: 동기 통신 시 외부(Discord) 서버 응답 지연으로 인해 우리 서버의 회원가입 처리 로직(메인 스레드)이 멈추는(Hang) 현상을 방지하고자, RestTemplateBuilder를 사용하여 connectTimeout과 readTimeout을 각각 3초로 설정했습니다.
- 독립적인 트랜잭션 흐름: 디스코드 알림 전송 로직을 try-catch 블록으로 감싸서, 알림 전송 과정에서 예외가 발생하더라도 메인 비즈니스 로직(회원가입 완료)은 정상적으로 응답하도록 구현했습니다.

<img width="252" height="514" alt="image" src="https://github.com/user-attachments/assets/eb72bbc0-f271-4707-a012-dc11405a45b4" />

따따 디스코드 채널에 새로운 채팅채널을 추가했습니다.

<img width="423" height="70" alt="image" src="https://github.com/user-attachments/assets/0c353d72-8194-4f41-a9d3-8d349ff5a4cb" />

이렇게 알림이 오게 됩니다.


## 💬고민사항 및 리뷰 요구사항 (Optional)
비동기 적용할까 했는데 배보다 배꼽이 커져서 안했습니다. 어차피 회원가입에는 아무 영향없음

## 비고 (Optional)
**⚠️ 환경 변수 추가 필요**
- 코드 머지 후 로컬의 application.yml 파일에 discord.webhook.url 값을 필수로 추가해 주어야 정상 작동합니다! (노션 수정 완료)
- 머지 진행하기 전에 github action의 variable도 수정 예정